### PR TITLE
feat(tui): add curses-based arbitrage monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,23 @@ Phase 2:
 Move arb to WebSockets / connectors, add multi‑symbol rotation, inventory rebalancing, Prometheus.
 
 Add stablecoin auto‑allocator logic with thresholded moves.
+
+## Usage
+
+The `arbit.py` script now exposes a small curses based TUI for monitoring
+triangular arbitrage opportunities on a single exchange.  Install
+dependencies (`pip install ccxt`) and run:
+
+```bash
+python arbit.py --tui
+```
+
+To run a finite number of iterations without the UI for testing or
+scripting, use the `--cycles` flag:
+
+```bash
+python arbit.py --cycles 5
+```
+
+The script fetches order books for `ETH/USDT`, `BTC/ETH` and `BTC/USDT`
+and prints the estimated net return of the USDT→ETH→BTC→USDT cycle.

--- a/arbit.py
+++ b/arbit.py
@@ -1,55 +1,116 @@
-# arbit.py
+"""Simple triangular arbitrage monitor with optional TUI interface.
 
-import os, ccxt, time, math
+The script polls three markets on a single exchange to detect a
+USDT→ETH→BTC→USDT cycle. When the net return exceeds the configured
+threshold, the opportunity is logged.  A minimal curses based TUI can be
+launched to visualise the live spreads and profit estimate.
+"""
 
-EX = "kraken"  # or binance, etc.
-symAB, symBC, symAC = "ETH/USDT", "BTC/ETH", "BTC/USDT"
-FEE = 0.001  # 0.1% taker as example; fetch from exchange
-THRESH = 0.001  # 0.10% net minimum
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from typing import Dict, Tuple, TYPE_CHECKING
+
+import curses
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    import ccxt  # type: ignore
+
+EX = "kraken"  # default exchange; configurable via --exchange
+SYM_AB, SYM_BC, SYM_AC = "ETH/USDT", "BTC/ETH", "BTC/USDT"
+FEE = 0.001  # 0.1% taker fee; fetch from exchange for real usage
+THRESH = 0.001  # 0.10% minimum net threshold
 QTY_USDT = 200  # per cycle notional cap
 
-ex = getattr(ccxt, EX)(
-    {
-        "apiKey": os.getenv("API_KEY"),
-        "secret": os.getenv("API_SECRET"),
-        "enableRateLimit": True,
-    }
-)
+
+def top(ob: Dict[str, list]) -> Tuple[float | None, float | None]:
+    """Return best bid and ask prices from a CCXT order book."""
+
+    bid = ob["bids"][0][0] if ob.get("bids") else None
+    ask = ob["asks"][0][0] if ob.get("asks") else None
+    return bid, ask
 
 
-def top(ob):
-    # returns best bid, best ask
-    bids = ob["bids"][0][0] if ob["bids"] else None
-    asks = ob["asks"][0][0] if ob["asks"] else None
-    return bids, asks
+def compute_net(bid_ab: float, ask_ab: float, bid_bc: float, ask_bc: float,
+                bid_ac: float, ask_ac: float, fee: float = FEE) -> float:
+    """Compute net gain of the USDT→ETH→BTC→USDT cycle."""
+
+    gross = (1 / ask_ab) * bid_bc * bid_ac
+    return gross * (1 - fee) ** 3 - 1
 
 
-while True:
-    obAB = ex.fetch_order_book(symAB, 10)
-    obBC = ex.fetch_order_book(symBC, 10)
-    obAC = ex.fetch_order_book(symAC, 10)
+def run_loop(ex: "ccxt.Exchange", cycles: int | None = None,
+             screen: curses.window | None = None) -> None:
+    """Continuously poll order books and report arbitrage opportunities.
 
-    bidAB, askAB = top(obAB)
-    bidBC, askBC = top(obBC)
-    bidAC, askAC = top(obAC)
-    if None in (bidAB, askAB, bidBC, askBC, bidAC, askAC):
-        time.sleep(0.2)
-        continue
+    Args:
+        ex: Initialised CCXT exchange instance.
+        cycles: Number of iterations to run. ``None`` runs forever.
+        screen: Optional curses window for TUI display.
+    """
 
-    # Cycle: USDT -> ETH -> BTC -> USDT
-    gross = (1 / askAB) * bidBC * bidAC
-    net = gross * (1 - FEE) ** 3 - 1
+    i = 0
+    while cycles is None or i < cycles:
+        ob_ab = ex.fetch_order_book(SYM_AB, 10)
+        ob_bc = ex.fetch_order_book(SYM_BC, 10)
+        ob_ac = ex.fetch_order_book(SYM_AC, 10)
 
-    if net >= THRESH:
-        # size-based on depth: keep small, respect min notionals
-        usdt = min(QTY_USDT, askAB * obAB["asks"][0][1])  # crude depth cap
-        eth_qty = usdt / askAB
-        btc_qty = eth_qty * bidBC
+        bid_ab, ask_ab = top(ob_ab)
+        bid_bc, ask_bc = top(ob_bc)
+        bid_ac, ask_ac = top(ob_ac)
+        if None in (bid_ab, ask_ab, bid_bc, ask_bc, bid_ac, ask_ac):
+            time.sleep(0.2)
+            continue
 
-        # Place IOC/FOK market/limit with tight slippage controls
-        # (pseudo; adapt to your exchange’s order flags)
-        # ex.create_order(symAB, 'market', 'buy', eth_qty)
-        # ex.create_order(symBC, 'market', 'sell', eth_qty)  # sell ETH for BTC
-        # ex.create_order(symAC, 'market', 'sell', btc_qty)  # sell BTC for USDT
-        print(f"Arb! est_net={net:.4%} notional≈${usdt:.2f}")
-    time.sleep(0.05)
+        net = compute_net(bid_ab, ask_ab, bid_bc, ask_bc, bid_ac, ask_ac)
+        if net >= THRESH:
+            usdt = min(QTY_USDT, ask_ab * ob_ab["asks"][0][1])
+            message = f"Arb! est_net={net:.4%} notional≈${usdt:.2f}"
+        else:
+            message = f"net={net:.4%}"
+
+        if screen:
+            screen.erase()
+            screen.addstr(0, 0, f"{SYM_AB}: bid {bid_ab:.2f} / ask {ask_ab:.2f}")
+            screen.addstr(1, 0, f"{SYM_BC}: bid {bid_bc:.2f} / ask {ask_bc:.2f}")
+            screen.addstr(2, 0, f"{SYM_AC}: bid {bid_ac:.2f} / ask {ask_ac:.2f}")
+            screen.addstr(4, 0, message)
+            screen.refresh()
+        else:
+            print(message)
+
+        i += 1
+        time.sleep(0.05)
+
+
+def main() -> None:
+    """Entry point for CLI usage."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--exchange", default=EX, help="ccxt exchange id")
+    parser.add_argument("--tui", action="store_true", help="enable curses UI")
+    parser.add_argument("--cycles", type=int, default=None,
+                        help="number of iterations to run")
+    args = parser.parse_args()
+
+    import ccxt  # type: ignore
+
+    ex_class = getattr(ccxt, args.exchange)
+    ex = ex_class(
+        {
+            "apiKey": os.getenv("API_KEY"),
+            "secret": os.getenv("API_SECRET"),
+            "enableRateLimit": True,
+        }
+    )
+
+    if args.tui:
+        curses.wrapper(lambda scr: run_loop(ex, args.cycles, scr))
+    else:
+        run_loop(ex, args.cycles)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refactor arbitrage script into functions with docstrings
- add curses-powered TUI for live spread and net return display
- document usage and CLI options in README

## Testing
- `python -m py_compile arbit.py`
- `python arbit.py --cycles 1` *(fails: ModuleNotFoundError: No module named 'ccxt')*


------
https://chatgpt.com/codex/tasks/task_e_68a907f621708329af1e07d1c68d316e