### PR TITLE
feat: add config settings and data models package

### DIFF
--- a/arbit/__init__.py
+++ b/arbit/__init__.py
@@ -1,0 +1,12 @@
+"""Core package for triangular arbitrage utilities."""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - optional dependency
+    from .config import Settings
+except Exception:  # pragma: no cover - pydantic may be missing
+    Settings = None  # type: ignore
+
+from .models import Triangle, OrderSpec, Fill
+
+__all__ = ["Settings", "Triangle", "OrderSpec", "Fill"]

--- a/arbit/config.py
+++ b/arbit/config.py
@@ -1,0 +1,30 @@
+"""Application configuration using Pydantic settings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables.
+
+    Attributes:
+        api_key: API key for exchange authentication.
+        api_secret: API secret for exchange authentication.
+        net_threshold: Minimum acceptable net profit threshold.
+        data_dir: Directory for storing runtime data.
+        log_path: File path for log output.
+    """
+
+    api_key: str = Field(..., description="Exchange API key")
+    api_secret: str = Field(..., description="Exchange API secret")
+    net_threshold: float = Field(0.001, description="Minimum net return threshold")
+    data_dir: Path = Field(Path("./data"), description="Directory for storing data")
+    log_path: Path = Field(Path("./arbit.log"), description="Path for log file")
+
+    class Config:
+        env_prefix = "ARBIT_"
+        env_file = ".env"
+        case_sensitive = False

--- a/arbit/models.py
+++ b/arbit/models.py
@@ -1,0 +1,40 @@
+"""Shared data models for arbitrage operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, Optional
+
+
+@dataclass(frozen=True)
+class Triangle:
+    """Trading symbols forming a triangular arbitrage path."""
+
+    leg_ab: str
+    leg_bc: str
+    leg_ac: str
+
+
+@dataclass(frozen=True)
+class OrderSpec:
+    """Specification for placing an order on an exchange."""
+
+    symbol: str
+    side: Literal["buy", "sell"]
+    quantity: float
+    price: Optional[float] = None
+    order_type: Literal["limit", "market"] = "limit"
+
+
+@dataclass(frozen=True)
+class Fill:
+    """Execution details of a completed order."""
+
+    order_id: str
+    symbol: str
+    side: Literal["buy", "sell"]
+    price: float
+    quantity: float
+    fee: float
+    timestamp: datetime | None = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+def test_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("pydantic")
+    from arbit.config import Settings
+
+    monkeypatch.setenv("ARBIT_API_KEY", "k")
+    monkeypatch.setenv("ARBIT_API_SECRET", "s")
+    settings = Settings()
+    assert settings.api_key == "k"
+    assert settings.api_secret == "s"
+    assert settings.net_threshold == 0.001
+    assert settings.data_dir.name == "data"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,22 @@
+from arbit.models import Triangle, OrderSpec, Fill
+
+
+def test_triangle() -> None:
+    tri = Triangle("ETH/USDT", "BTC/ETH", "BTC/USDT")
+    assert tri.leg_ab == "ETH/USDT"
+    assert tri.leg_bc == "BTC/ETH"
+    assert tri.leg_ac == "BTC/USDT"
+
+
+def test_order_spec() -> None:
+    order = OrderSpec(symbol="ETH/USDT", side="buy", quantity=1.0)
+    assert order.order_type == "limit"
+    assert order.price is None
+
+
+def test_fill() -> None:
+    fill = Fill(
+        order_id="1", symbol="ETH/USDT", side="buy", price=10.0, quantity=1.0, fee=0.1
+    )
+    assert fill.order_id == "1"
+    assert fill.fee == 0.1


### PR DESCRIPTION
## Summary
- add `arbit` package with Pydantic-based configuration
- introduce core data models for triangles, orders, and fills
- cover settings and model basics with unit tests

## Testing
- `ruff check arbit tests`
- `mypy --ignore-missing-imports arbit tests`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aab9f931e48329bec15966a19498b8