### PR TITLE
feat(adapters): add exchange adapter interface

### DIFF
--- a/arbit/adapters/__init__.py
+++ b/arbit/adapters/__init__.py
@@ -1,0 +1,10 @@
+"""Exchange adapter interfaces and implementations."""
+
+from .base import ExchangeAdapter
+
+try:  # pragma: no cover - optional dependency
+    from .ccxt_adapter import CCXTAdapter
+except Exception:  # pragma: no cover
+    CCXTAdapter = None  # type: ignore
+
+__all__ = ["ExchangeAdapter", "CCXTAdapter"]

--- a/arbit/adapters/base.py
+++ b/arbit/adapters/base.py
@@ -1,0 +1,28 @@
+"""Abstract base classes for exchange connectivity."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from ..models import Fill, OrderSpec
+
+
+class ExchangeAdapter(ABC):
+    """Abstract base class defining a minimal exchange interface."""
+
+    @abstractmethod
+    def fetch_order_book(self, symbol: str) -> dict[str, Any]:
+        """Return the current order book for *symbol*."""
+
+    @abstractmethod
+    def create_order(self, order: OrderSpec) -> Fill:
+        """Place an *order* on the exchange and return a :class:`~arbit.models.Fill`."""
+
+    @abstractmethod
+    def cancel_order(self, order_id: str, symbol: str) -> None:
+        """Cancel an open order identified by *order_id* on *symbol*."""
+
+    @abstractmethod
+    def fetch_balance(self, asset: str) -> float:
+        """Return available balance for the given *asset*."""

--- a/arbit/adapters/ccxt_adapter.py
+++ b/arbit/adapters/ccxt_adapter.py
@@ -1,0 +1,72 @@
+"""CCXT based implementation of :class:`ExchangeAdapter`."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import ccxt  # type: ignore
+
+from ..models import Fill, OrderSpec
+from .base import ExchangeAdapter
+
+
+class CCXTAdapter(ExchangeAdapter):
+    """Adapter providing access to exchanges supported by `ccxt`.
+
+    Currently limited to the ``alpaca`` and ``kraken`` exchanges.
+    """
+
+    def __init__(self, exchange_id: str, api_key: str, api_secret: str) -> None:
+        """Instantiate adapter for the given *exchange_id*.
+
+        Args:
+            exchange_id: Identifier of the exchange (``alpaca`` or ``kraken``).
+            api_key: API key for authentication.
+            api_secret: API secret for authentication.
+        """
+        if exchange_id not in {"alpaca", "kraken"}:
+            raise ValueError(f"Unsupported exchange: {exchange_id}")
+
+        exchange_cls = getattr(ccxt, exchange_id)
+        self.client = exchange_cls(
+            {
+                "apiKey": api_key,
+                "secret": api_secret,
+                "enableRateLimit": True,
+            }
+        )
+
+    def fetch_order_book(self, symbol: str) -> dict[str, Any]:
+        """Return the current order book for *symbol*."""
+        return self.client.fetch_order_book(symbol)
+
+    def create_order(self, order: OrderSpec) -> Fill:
+        """Place *order* on the exchange and return fill details."""
+        result = self.client.create_order(
+            order.symbol, order.order_type, order.side, order.quantity, order.price
+        )
+        timestamp = result.get("timestamp")
+        ts = datetime.fromtimestamp(timestamp / 1000) if timestamp else None
+        fee_cost = 0.0
+        fee = result.get("fee")
+        if isinstance(fee, dict):
+            fee_cost = float(fee.get("cost", 0))
+        return Fill(
+            order_id=str(result.get("id")),
+            symbol=order.symbol,
+            side=order.side,
+            price=float(result.get("price") or 0),
+            quantity=float(result.get("amount") or order.quantity),
+            fee=fee_cost,
+            timestamp=ts,
+        )
+
+    def cancel_order(self, order_id: str, symbol: str) -> None:
+        """Cancel an open order on the exchange."""
+        self.client.cancel_order(order_id, symbol)
+
+    def fetch_balance(self, asset: str) -> float:
+        """Return available balance for *asset*."""
+        balance = self.client.fetch_balance()
+        return float(balance.get("free", {}).get(asset, 0))

--- a/tests/test_ccxt_adapter.py
+++ b/tests/test_ccxt_adapter.py
@@ -1,0 +1,67 @@
+import pytest
+
+ccxt = pytest.importorskip("ccxt")
+
+from arbit.adapters import CCXTAdapter, ExchangeAdapter
+from arbit.models import OrderSpec
+
+
+def test_initialization() -> None:
+    adapter = CCXTAdapter("alpaca", "k", "s")
+    assert isinstance(adapter, ExchangeAdapter)
+    assert adapter.client.id == "alpaca"
+
+
+def test_fetch_order_book(monkeypatch) -> None:
+    adapter = CCXTAdapter("kraken", "k", "s")
+
+    def fake_fetch_order_book(symbol: str) -> dict:
+        assert symbol == "BTC/USD"
+        return {"bids": [], "asks": []}
+
+    monkeypatch.setattr(adapter.client, "fetch_order_book", fake_fetch_order_book)
+    order_book = adapter.fetch_order_book("BTC/USD")
+    assert order_book == {"bids": [], "asks": []}
+
+
+def test_create_order(monkeypatch) -> None:
+    adapter = CCXTAdapter("alpaca", "k", "s")
+
+    def fake_create_order(symbol, order_type, side, amount, price):
+        return {
+            "id": "1",
+            "price": price,
+            "amount": amount,
+            "fee": {"cost": 0.1},
+        }
+
+    monkeypatch.setattr(adapter.client, "create_order", fake_create_order)
+    order = OrderSpec(symbol="ETH/USDT", side="buy", quantity=1.0, price=1000.0)
+    fill = adapter.create_order(order)
+    assert fill.order_id == "1"
+    assert fill.quantity == 1.0
+    assert fill.fee == 0.1
+
+
+def test_cancel_order(monkeypatch) -> None:
+    adapter = CCXTAdapter("alpaca", "k", "s")
+    called: dict[str, str] = {}
+
+    def fake_cancel_order(order_id: str, symbol: str) -> None:
+        called["order_id"] = order_id
+        called["symbol"] = symbol
+
+    monkeypatch.setattr(adapter.client, "cancel_order", fake_cancel_order)
+    adapter.cancel_order("1", "ETH/USDT")
+    assert called == {"order_id": "1", "symbol": "ETH/USDT"}
+
+
+def test_fetch_balance(monkeypatch) -> None:
+    adapter = CCXTAdapter("kraken", "k", "s")
+
+    def fake_fetch_balance() -> dict:
+        return {"free": {"USD": 10.0}}
+
+    monkeypatch.setattr(adapter.client, "fetch_balance", fake_fetch_balance)
+    balance = adapter.fetch_balance("USD")
+    assert balance == 10.0


### PR DESCRIPTION
## Summary
- add ExchangeAdapter base class defining minimal trading interface
- implement CCXTAdapter for Alpaca and Kraken exchanges
- add tests for CCXTAdapter functionality

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aabb895cec83299f60a45e5cb421c8