### PR TITLE
feat(engine): add triangle helpers and executor orchestrator

### DIFF
--- a/arbit/engine/__init__.py
+++ b/arbit/engine/__init__.py
@@ -1,0 +1,8 @@
+"""Execution and calculation helpers for the arbitrage engine."""
+
+from __future__ import annotations
+
+from .triangle import top, net_edge_cycle, size_from_depth
+from .executor import try_triangle
+
+__all__ = ["top", "net_edge_cycle", "size_from_depth", "try_triangle"]

--- a/arbit/engine/executor.py
+++ b/arbit/engine/executor.py
@@ -1,0 +1,62 @@
+"""Order execution orchestration for triangular arbitrage."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .triangle import top, net_edge_cycle, size_from_depth
+from ..adapters.base import ExchangeAdapter
+from ..models import Triangle, OrderSpec
+
+
+def try_triangle(
+    adapter: ExchangeAdapter,
+    triangle: Triangle,
+    order_books: Dict[str, dict],
+    threshold: float,
+) -> bool:
+    """Attempt to execute a triangular arbitrage cycle.
+
+    The function inspects the provided *order_books* and, if the implied net
+    return exceeds *threshold*, submits three linked orders using *adapter*.
+
+    Args:
+        adapter: Exchange adapter used for order placement.
+        triangle: Trading symbols forming the arbitrage path.
+        order_books: Mapping of symbol to order book data containing ``bids`` and
+            ``asks``.
+        threshold: Minimum acceptable net return. Values at or below this level
+            cause the trade to be skipped.
+
+    Returns:
+        ``True`` if the three orders were submitted, otherwise ``False``.
+    """
+    try:
+        ab = order_books[triangle.leg_ab]
+        bc = order_books[triangle.leg_bc]
+        ac = order_books[triangle.leg_ac]
+    except KeyError:
+        return False
+
+    ab_price, ab_qty = top(ab.get("asks", []))
+    bc_price, bc_qty = top(bc.get("bids", []))
+    ac_price, ac_qty = top(ac.get("bids", []))
+
+    net = net_edge_cycle([1 / ab_price if ab_price else 0.0, bc_price, ac_price])
+    if net <= threshold:
+        return False
+
+    size = size_from_depth([(ab_price, ab_qty), (bc_price, bc_qty), (ac_price, ac_qty)])
+    if size <= 0.0:
+        return False
+
+    orders = [
+        OrderSpec(symbol=triangle.leg_ab, side="buy", quantity=size, price=ab_price),
+        OrderSpec(symbol=triangle.leg_bc, side="sell", quantity=size, price=bc_price),
+        OrderSpec(symbol=triangle.leg_ac, side="sell", quantity=size, price=ac_price),
+    ]
+
+    for order in orders:
+        adapter.create_order(order)
+
+    return True

--- a/arbit/engine/triangle.py
+++ b/arbit/engine/triangle.py
@@ -1,0 +1,57 @@
+"""Utility helpers for triangular arbitrage calculations."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def top(book_side: Sequence[tuple[float, float]]) -> tuple[float, float]:
+    """Return the top price and quantity for an order book side.
+
+    Args:
+        book_side: Sequence of ``(price, quantity)`` tuples ordered best first.
+
+    Returns:
+        A tuple ``(price, quantity)`` representing the best available level. If
+        *book_side* is empty, ``(0.0, 0.0)`` is returned.
+    """
+    if book_side:
+        return book_side[0]
+    return (0.0, 0.0)
+
+
+def net_edge_cycle(edges: Sequence[float]) -> float:
+    """Return the net result for a sequence of exchange rate edges.
+
+    The function multiplies the provided *edges* together and subtracts one,
+    yielding the net gain relative to the starting amount.
+
+    Args:
+        edges: Iterable of exchange rate multipliers.
+
+    Returns:
+        Net profit/loss as a multiplier minus one.
+    """
+    net = 1.0
+    for edge in edges:
+        net *= edge
+    return net - 1.0
+
+
+def size_from_depth(levels: Sequence[tuple[float, float]]) -> float:
+    """Determine executable quantity based on top-of-book levels.
+
+    The function returns the smallest quantity across all *levels*, representing
+    the maximum size that can be traded without exceeding any single level's
+    available quantity.
+
+    Args:
+        levels: Sequence of ``(price, quantity)`` pairs.
+
+    Returns:
+        Maximum trade size permitted by the supplied *levels*. ``0.0`` is
+        returned when *levels* is empty.
+    """
+    if not levels:
+        return 0.0
+    return min(qty for _, qty in levels)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,58 @@
+from arbit.engine.executor import try_triangle
+from arbit.models import Triangle, OrderSpec, Fill
+from arbit.adapters.base import ExchangeAdapter
+
+
+class DummyAdapter(ExchangeAdapter):
+    def __init__(self) -> None:
+        self.orders: list[OrderSpec] = []
+
+    def fetch_order_book(self, symbol: str) -> dict:
+        return {}
+
+    def create_order(self, order: OrderSpec) -> Fill:
+        self.orders.append(order)
+        return Fill(
+            order_id=str(len(self.orders)),
+            symbol=order.symbol,
+            side=order.side,
+            price=order.price or 0.0,
+            quantity=order.quantity,
+            fee=0.0,
+        )
+
+    def cancel_order(self, order_id: str, symbol: str) -> None:  # pragma: no cover - not used
+        pass
+
+    def fetch_balance(self, asset: str) -> float:  # pragma: no cover - not used
+        return 0.0
+
+
+def profitable_books() -> dict[str, dict[str, list[tuple[float, float]]]]:
+    return {
+        "ETH/USDT": {"asks": [(100.0, 10.0)], "bids": []},
+        "BTC/ETH": {"bids": [(0.1, 10.0)], "asks": []},
+        "BTC/USDT": {"bids": [(1100.0, 10.0)], "asks": []},
+    }
+
+
+def unprofitable_books() -> dict[str, dict[str, list[tuple[float, float]]]]:
+    data = profitable_books()
+    data["BTC/USDT"] = {"bids": [(1000.0, 10.0)], "asks": []}
+    return data
+
+
+def test_try_triangle_executes_on_profit() -> None:
+    adapter = DummyAdapter()
+    tri = Triangle("ETH/USDT", "BTC/ETH", "BTC/USDT")
+    placed = try_triangle(adapter, tri, profitable_books(), 0.01)
+    assert placed is True
+    assert len(adapter.orders) == 3
+
+
+def test_try_triangle_skips_when_unprofitable() -> None:
+    adapter = DummyAdapter()
+    tri = Triangle("ETH/USDT", "BTC/ETH", "BTC/USDT")
+    placed = try_triangle(adapter, tri, unprofitable_books(), 0.01)
+    assert placed is False
+    assert len(adapter.orders) == 0

--- a/tests/test_triangle_helpers.py
+++ b/tests/test_triangle_helpers.py
@@ -1,0 +1,18 @@
+import pytest
+
+from arbit.engine.triangle import net_edge_cycle, size_from_depth, top
+
+
+def test_top() -> None:
+    assert top([(1.0, 2.0), (0.9, 1.0)]) == (1.0, 2.0)
+    assert top([]) == (0.0, 0.0)
+
+
+def test_net_edge_cycle() -> None:
+    assert net_edge_cycle([1.1, 1.2]) == pytest.approx(0.32)
+
+
+def test_size_from_depth() -> None:
+    levels = [(1.0, 5.0), (2.0, 3.0), (3.0, 4.0)]
+    assert size_from_depth(levels) == 3.0
+    assert size_from_depth([]) == 0.0


### PR DESCRIPTION
## Summary
- add engine.triangle with helpers: `top`, `net_edge_cycle`, and `size_from_depth`
- implement `try_triangle` in engine.executor to evaluate arbitrage opportunities and submit orders
- cover new utilities and execution logic with unit tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac903445883299b8effd67f6219e1