### PR TITLE
feat: add SQLite persistence and Prometheus metrics exporter

### DIFF
--- a/arbit/metrics/__init__.py
+++ b/arbit/metrics/__init__.py
@@ -1,0 +1,2 @@
+"""Prometheus metrics helpers."""
+

--- a/arbit/metrics/exporter.py
+++ b/arbit/metrics/exporter.py
@@ -1,0 +1,18 @@
+"""Prometheus metrics exporter and helpers."""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge, start_http_server
+
+# Counters
+ORDERS_TOTAL = Counter("orders_total", "Total number of orders placed")
+FILLS_TOTAL = Counter("fills_total", "Total number of fills recorded")
+
+# Gauges
+PROFIT_TOTAL = Gauge("profit_total", "Accumulated profit in quote currency")
+
+
+def start_metrics_server(port: int = 8000) -> None:
+    """Start an HTTP server exposing Prometheus metrics."""
+    start_http_server(port)
+

--- a/arbit/persistence/__init__.py
+++ b/arbit/persistence/__init__.py
@@ -1,0 +1,2 @@
+"""Persistence utilities for SQLite-backed storage."""
+

--- a/arbit/persistence/db.py
+++ b/arbit/persistence/db.py
@@ -1,0 +1,80 @@
+"""SQLite persistence layer with simple insert helpers."""
+
+from __future__ import annotations
+
+import sqlite3
+from sqlite3 import Connection
+
+from ..models import Fill, Triangle
+
+
+def init_db(db_path: str = "arbit.db") -> Connection:
+    """Create a database connection and ensure required tables exist."""
+    conn = sqlite3.connect(db_path)
+    create_schema(conn)
+    return conn
+
+
+def create_schema(conn: Connection) -> None:
+    """Create database tables if they are missing."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS triangles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            leg_ab TEXT NOT NULL,
+            leg_bc TEXT NOT NULL,
+            leg_ac TEXT NOT NULL
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS fills (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            order_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            price REAL NOT NULL,
+            quantity REAL NOT NULL,
+            fee REAL NOT NULL,
+            timestamp TEXT
+        )
+        """
+    )
+    conn.commit()
+
+
+def insert_triangle(conn: Connection, triangle: Triangle) -> int:
+    """Insert a triangle record and return its row id."""
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO triangles (leg_ab, leg_bc, leg_ac) VALUES (?, ?, ?)",
+        (triangle.leg_ab, triangle.leg_bc, triangle.leg_ac),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def insert_fill(conn: Connection, fill: Fill) -> int:
+    """Insert a fill record and return its row id."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO fills (
+            order_id, symbol, side, price, quantity, fee, timestamp
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            fill.order_id,
+            fill.symbol,
+            fill.side,
+            fill.price,
+            fill.quantity,
+            fill.fee,
+            fill.timestamp.isoformat() if fill.timestamp else None,
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid
+

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from arbit.models import Fill, Triangle
+from arbit.persistence import db
+
+
+def test_insert_triangle_and_fill():
+    conn = db.init_db(":memory:")
+    triangle = Triangle("BTC/USDT", "USDT/ETH", "BTC/ETH")
+    t_id = db.insert_triangle(conn, triangle)
+    assert t_id == 1
+
+    fill = Fill(
+        order_id="o1",
+        symbol="BTC/USDT",
+        side="buy",
+        price=100.0,
+        quantity=0.5,
+        fee=0.1,
+        timestamp=datetime.fromtimestamp(0),
+    )
+    f_id = db.insert_fill(conn, fill)
+    assert f_id == 1
+
+    cur = conn.cursor()
+    cur.execute("SELECT leg_ab, leg_bc, leg_ac FROM triangles")
+    assert cur.fetchone() == ("BTC/USDT", "USDT/ETH", "BTC/ETH")
+    cur.execute("SELECT order_id, symbol, side, price, quantity, fee FROM fills")
+    assert cur.fetchone() == ("o1", "BTC/USDT", "buy", 100.0, 0.5, 0.1)

--- a/tests/test_metrics_exporter.py
+++ b/tests/test_metrics_exporter.py
@@ -1,0 +1,13 @@
+import pytest
+
+pytest.importorskip("prometheus_client")
+
+from arbit.metrics import exporter
+
+
+def test_metrics_counters_and_gauge():
+    exporter.ORDERS_TOTAL.inc()
+    exporter.PROFIT_TOTAL.set(5.0)
+    exporter.start_metrics_server(8001)
+    assert exporter.ORDERS_TOTAL._value.get() == 1.0
+    assert exporter.PROFIT_TOTAL._value.get() == 5.0


### PR DESCRIPTION
## Summary
- add SQLite persistence module with schema creation and insert helpers
- expose Prometheus counters, gauge, and server starter
- cover persistence and metrics utilities with tests (metrics skipped without prometheus_client)

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaca7e4a788329956c1dfa84176a94