### PR TITLE
test(engine): add dedicated tests for net_edge_cycle and size_from_depth

### DIFF
--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,0 +1,15 @@
+"""Tests for mathematical helper functions."""
+
+import pytest
+
+from arbit.engine.triangle import net_edge_cycle
+
+
+def test_net_edge_cycle_product_minus_one() -> None:
+    """Net edge cycle multiplies edges and subtracts one."""
+    assert net_edge_cycle([1.1, 1.2]) == pytest.approx(0.32)
+
+
+def test_net_edge_cycle_empty_edges() -> None:
+    """No edges should yield zero net cycle."""
+    assert net_edge_cycle([]) == 0.0

--- a/tests/test_triangle.py
+++ b/tests/test_triangle.py
@@ -1,0 +1,14 @@
+"""Tests for triangle utility helpers."""
+
+from arbit.engine.triangle import size_from_depth
+
+
+def test_size_from_depth_uses_smallest_quantity() -> None:
+    """Return the minimum quantity across all levels."""
+    levels = [(1.0, 5.0), (2.0, 3.0), (3.0, 4.0)]
+    assert size_from_depth(levels) == 3.0
+
+
+def test_size_from_depth_empty_levels() -> None:
+    """Empty levels should result in zero executable size."""
+    assert size_from_depth([]) == 0.0


### PR DESCRIPTION
## Summary
- add tests for `net_edge_cycle` math helper
- ensure `size_from_depth` returns minimum quantity and handles empty levels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad0b4640c832987079811863d0482