### PR TITLE
feat(stake): load contract data from configuration

### DIFF
--- a/arbit/config.py
+++ b/arbit/config.py
@@ -16,6 +16,10 @@ class Settings(BaseSettings):
         net_threshold: Minimum acceptable net profit threshold.
         data_dir: Directory for storing runtime data.
         log_path: File path for log output.
+        usdc_address: Address of the USDC contract.
+        pool_address: Address of the Aave v3 Pool contract.
+        usdc_abi_path: Filesystem path to the USDC contract ABI.
+        pool_abi_path: Filesystem path to the Aave v3 Pool ABI.
     """
 
     api_key: str = Field(..., description="Exchange API key")
@@ -23,6 +27,10 @@ class Settings(BaseSettings):
     net_threshold: float = Field(0.001, description="Minimum net return threshold")
     data_dir: Path = Field(Path("./data"), description="Directory for storing data")
     log_path: Path = Field(Path("./arbit.log"), description="Path for log file")
+    usdc_address: str = Field(..., description="USDC contract address")
+    pool_address: str = Field(..., description="Aave v3 Pool contract address")
+    usdc_abi_path: str = Field("erc20.json", description="Path to USDC ABI file")
+    pool_abi_path: str = Field("aave_pool.json", description="Path to Aave v3 Pool ABI file")
 
     class Config:
         env_prefix = "ARBIT_"

--- a/stake.py
+++ b/stake.py
@@ -1,30 +1,57 @@
+"""Stake USDC into Aave v3 using configured contract data.
+
+This module demonstrates approving USDC for spending by the Aave v3 Pool
+contract and then supplying it to the pool. Contract addresses and ABI file
+paths are loaded from :class:`arbit.config.Settings`.
+
+Usage:
+    Export ``RPC_URL``, ``PRIVATE_KEY`` and the necessary ``ARBIT_`` settings
+    before running the module.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
 from web3 import Web3
-import json, os
 
-RPC = os.getenv("RPC_URL")  # e.g., Infura/Alchemy
-w3 = Web3(
-    Web3.HTTPProvider(RPC)
-)  # needs a node provider connection :contentReference[oaicite:6]{index=6}
-acct = w3.eth.account.from_key(os.getenv("PRIVATE_KEY"))
+from arbit.config import Settings
 
-# You’ll need:
-# - USDC ERC20 contract (approve)
-# - Aave v3 Pool contract (supply)
-# Fetch addresses/ABIs from Aave docs / deployment registry for your chain. :contentReference[oaicite:7]{index=7}
 
-USDC = w3.eth.contract(address=..., abi=json.load(open("erc20.json")))
-POOL = w3.eth.contract(address=..., abi=json.load(open("aave_pool.json")))
+def stake_usdc(amount: int) -> None:
+    """Approve and deposit ``amount`` of USDC into Aave v3.
 
-amount = 1_000 * 10**6  # 1000 USDC (6 decimals)
+    Args:
+        amount: USDC amount in base units (6 decimals) to supply.
+    """
 
-# 1) Approve
-tx1 = USDC.functions.approve(POOL.address, amount).build_transaction({...})
-signed1 = acct.sign_transaction(tx1)
-w3.eth.send_raw_transaction(signed1.rawTransaction)
+    settings = Settings()
 
-# 2) Supply (Aave v3 Pool.supply(asset, amount, onBehalfOf, referralCode))
-tx2 = POOL.functions.supply(USDC.address, amount, acct.address, 0).build_transaction(
-    {...}
-)
-signed2 = acct.sign_transaction(tx2)
-w3.eth.send_raw_transaction(signed2.rawTransaction)
+    w3 = Web3(Web3.HTTPProvider(os.getenv("RPC_URL")))
+    acct = w3.eth.account.from_key(os.getenv("PRIVATE_KEY"))
+
+    usdc_abi = json.loads(Path(settings.usdc_abi_path).read_text())
+    pool_abi = json.loads(Path(settings.pool_abi_path).read_text())
+
+    usdc = w3.eth.contract(address=settings.usdc_address, abi=usdc_abi)
+    pool = w3.eth.contract(address=settings.pool_address, abi=pool_abi)
+
+    tx1 = usdc.functions.approve(pool.address, amount).build_transaction({...})
+    signed1 = acct.sign_transaction(tx1)
+    w3.eth.send_raw_transaction(signed1.rawTransaction)
+
+    tx2 = pool.functions.supply(
+        usdc.address, amount, acct.address, 0
+    ).build_transaction({
+        ...
+    })
+    signed2 = acct.sign_transaction(tx2)
+    w3.eth.send_raw_transaction(signed2.rawTransaction)
+
+
+if __name__ == "__main__":
+    AMOUNT = 1_000 * 10**6  # 1000 USDC (6 decimals)
+    stake_usdc(AMOUNT)
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,8 +7,16 @@ def test_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setenv("ARBIT_API_KEY", "k")
     monkeypatch.setenv("ARBIT_API_SECRET", "s")
+    monkeypatch.setenv("ARBIT_USDC_ADDRESS", "0xusdc")
+    monkeypatch.setenv("ARBIT_POOL_ADDRESS", "0xpool")
+    monkeypatch.setenv("ARBIT_USDC_ABI_PATH", "erc20.json")
+    monkeypatch.setenv("ARBIT_POOL_ABI_PATH", "pool.json")
     settings = Settings()
     assert settings.api_key == "k"
     assert settings.api_secret == "s"
     assert settings.net_threshold == 0.001
     assert settings.data_dir.name == "data"
+    assert settings.usdc_address == "0xusdc"
+    assert settings.pool_address == "0xpool"
+    assert settings.usdc_abi_path == "erc20.json"
+    assert settings.pool_abi_path == "pool.json"


### PR DESCRIPTION
## Summary
- document staking helper and load contract metadata from Settings
- expose Aave/USDC addresses and ABI paths in runtime configuration
- test that new configuration values are pulled from environment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad20074388329ad09c9dad843000c