### PR TITLE
feat: add docker setup and env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Example environment configuration for Arbit bot
+
+# Alpaca exchange credentials
+ARBIT_ALPACA_API_KEY=your_alpaca_api_key
+ARBIT_ALPACA_API_SECRET=your_alpaca_api_secret
+
+# Kraken exchange credentials
+ARBIT_KRAKEN_API_KEY=your_kraken_api_key
+ARBIT_KRAKEN_API_SECRET=your_kraken_api_secret
+
+# Shared settings
+# Minimum acceptable net profit threshold
+ARBIT_NET_THRESHOLD=0.001
+# Directory for runtime data
+ARBIT_DATA_DIR=/data
+# Path for log output
+ARBIT_LOG_PATH=/data/arbit.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN pip install --no-cache-dir \
+    ccxt \
+    websockets \
+    pydantic \
+    typer \
+    prometheus-client \
+    orjson
+
+COPY arbit ./arbit
+
+ENTRYPOINT ["python", "-m", "arbit.cli", "live"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  mf-alpaca:
+    build: .
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      ARBIT_API_KEY: ${ARBIT_ALPACA_API_KEY}
+      ARBIT_API_SECRET: ${ARBIT_ALPACA_API_SECRET}
+    volumes:
+      - ./data:/data
+    ports:
+      - "9109:9109"
+    command: ["--venue", "alpaca", "--metrics-port", "9109"]
+
+  mf-kraken:
+    build: .
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      ARBIT_API_KEY: ${ARBIT_KRAKEN_API_KEY}
+      ARBIT_API_SECRET: ${ARBIT_KRAKEN_API_SECRET}
+    volumes:
+      - ./data:/data
+    ports:
+      - "9110:9110"
+    command: ["--venue", "kraken", "--metrics-port", "9110"]


### PR DESCRIPTION
## Summary
- provide `.env.example` with keys for Alpaca/Kraken and shared config
- add Dockerfile for running bot
- add docker-compose services for Alpaca and Kraken

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad11c725c83299bf93c8aebbeee9f