### PR TITLE
refactor: unify Triangle dataclass usage

### DIFF
--- a/arbit/cli.py
+++ b/arbit/cli.py
@@ -3,7 +3,7 @@
 import time, typer, logging
 from arbit.config import settings
 from arbit.adapters.ccxt_adapter import CcxtAdapter
-from arbit.engine.triangle import Triangle
+from arbit.models import Triangle
 from arbit.engine.executor import try_triangle
 from arbit.metrics.exporter import start as prom_start, arb_cycles, pnl_gross
 
@@ -39,7 +39,7 @@ def keys_check():
 def fitness(venue: str = "alpaca", secs: int = 20):
     a = make(venue)
     t0 = time.time()
-    syms = {s for t in TRIS for s in (t.AB, t.BC, t.AC)}
+    syms = {s for t in TRIS for s in (t.leg_ab, t.leg_bc, t.leg_ac)}
     while time.time() - t0 < secs:
         for s in syms:
             ob = a.fetch_orderbook(s, 5)
@@ -60,9 +60,9 @@ def live(venue: str = "alpaca"):
     while True:
         for tri in TRIS:
             books = {
-                tri.AB: a.fetch_orderbook(tri.AB, 10),
-                tri.BC: a.fetch_orderbook(tri.BC, 10),
-                tri.AC: a.fetch_orderbook(tri.AC, 10),
+                tri.leg_ab: a.fetch_orderbook(tri.leg_ab, 10),
+                tri.leg_bc: a.fetch_orderbook(tri.leg_bc, 10),
+                tri.leg_ac: a.fetch_orderbook(tri.leg_ac, 10),
             }
             res = try_triangle(
                 a,

--- a/arbit/engine/triangle.py
+++ b/arbit/engine/triangle.py
@@ -1,17 +1,6 @@
 """Utility helpers for computing profitability and sizing in triangular markets."""
 
-from dataclasses import dataclass
 from typing import Iterable, List, Tuple
-
-
-@dataclass(frozen=True)
-class Triangle:
-    """Trading triangle consisting of three currency pairs."""
-
-    AB: str  # e.g., ETH/USDT
-    BC: str  # e.g., BTC/ETH
-    AC: str  # e.g., BTC/USDT
-
 
 def top(levels: List[Tuple[float, float]]) -> Tuple[float | None, float | None]:
     """Return best bid and ask from a list of ``(bid, ask)`` tuples.

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -14,7 +14,7 @@ sys.modules["arbit.config"] = types.SimpleNamespace(
 )
 
 from arbit.engine.executor import try_triangle
-from arbit.engine.triangle import Triangle
+from arbit.models import Triangle
 from arbit.adapters.base import ExchangeAdapter, OrderSpec
 
 


### PR DESCRIPTION
## Summary
- remove duplicate Triangle dataclass from engine utilities
- import shared Triangle model across CLI, executor, and tests
- switch attribute access to leg_ab/leg_bc/leg_ac fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab265db4fc8329b202fb783ffc30d5