### PR TITLE
refactor(metrics): rename collectors and server helper

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -302,10 +302,10 @@ services:
             res = try_tri(a, tri)
             if not res: continue
             if "error"                              in res:
-                arb_cycles.labels(venue, "error").inc()
+                ORDERS_TOTAL.labels(venue, "error").inc()
                 log.error(res["error"])                             ; continue
-            arb_cycles.labels(venue, "ok").inc()
-            pnl_gross.labels(venue).set(res["realized_usdt"])
+            ORDERS_TOTAL.labels(venue, "ok").inc()
+            PROFIT_TOTAL.labels(venue).set(res["realized_usdt"])
             for f in res                             ["fills"]: insert_trade(cx, venue, f)
             insert_cycle(cx, venue, tri, res["net_est"], res[                             "realized_usdt"])
             log.info(f"{venue} {tri} net_est={res['net_est']:.3%} realized={                             res['realized_usdt']:.2f} USDT")
@@ -367,11 +367,11 @@ Triangle(AB="ETH/USDT", BC="BTC/ETH", AC="BTC/USDT"),
 Triangle(AB="ETH/USDC", BC="BTC/ETH", AC="BTC/USDC"),
 ]
 
-def make_adapter(venue: cycles = Counter("mf_arb_cycles", "Arb cycles attempted", ["venue","result"])
-pnl_gross = Gauge("mf_pnl_gross_usdt", "Gross realized PnL in USDT", ["venue"])
+ORDERS_TOTAL = Counter("mf_orders_total", "Orders attempted", ["venue","result"])
+PROFIT_TOTAL = Gauge("mf_profit_total_usdt", "Gross realized PnL in USDT", ["venue"])
 latency_ms = Gauge("mf_loop_latency_ms", "Main loop latency")
 
-def start(port: int): start_http_server(port)
+def start_metrics_server(port: int): start_http_server(port)
 
 ````
 
@@ -387,7 +387,7 @@ from arbit.config import settings
 from arbit.adapters.ccxt_adapter import CcxtAdapter
 from arbit.engine.executor import try_tri
 from arbit.models import Triangle
-from arbit.metrics.exporter import start as prom_start, arb_cycles, pnl_gross
+from arbit.metrics.exporter import start_metrics_server, ORDERS_TOTAL, PROFIT_TOTAL
 from arbit.persistence.db import connect, insert_trade, insert_cycle
 
 app = typer.Typer()

--- a/arbit/cli.py
+++ b/arbit/cli.py
@@ -7,8 +7,7 @@ import typer
 from arbit.adapters.ccxt_adapter import CcxtAdapter
 from arbit.config import settings
 from arbit.engine.executor import try_triangle
-from arbit.metrics.exporter import arb_cycles, pnl_gross
-from arbit.metrics.exporter import start as prom_start
+from arbit.metrics.exporter import ORDERS_TOTAL, PROFIT_TOTAL, start_metrics_server
 from arbit.models import Triangle
 
 app = typer.Typer()
@@ -59,7 +58,7 @@ def fitness(venue: str = "alpaca", secs: int = 20):
 def live(venue: str = "alpaca"):
     """Continuously scan for profitable triangles and execute trades."""
     a = make(venue)
-    prom_start(settings.prom_port)
+    start_metrics_server(settings.prom_port)
     log.info(f"live@{venue} dry_run={settings.dry_run}")
     while True:
         for tri in TRIS:
@@ -76,8 +75,8 @@ def live(venue: str = "alpaca"):
             )
             if not res:
                 continue
-            pnl_gross.labels(venue).set(res["realized_usdt"])
-            arb_cycles.labels(venue, "ok").inc()
+            PROFIT_TOTAL.labels(venue).set(res["realized_usdt"])
+            ORDERS_TOTAL.labels(venue, "ok").inc()
             log.info(
                 f"{venue} {tri} net={res['net_est']:.3%} PnL={res['realized_usdt']:.2f} USDT"
             )

--- a/arbit/metrics/exporter.py
+++ b/arbit/metrics/exporter.py
@@ -1,8 +1,23 @@
-from prometheus_client import start_http_server, Counter, Gauge
+"""Prometheus metrics collectors and helpers.
 
-arb_cycles = Counter("arbit_cycles", "Arb cycles", ["venue", "result"])
-pnl_gross = Gauge("arbit_pnl_usdt", "Realized PnL (USDT)", ["venue"])
+This module exposes counters and gauges for tracking orders and profit as well as
+utilities for starting the metrics HTTP server.
+"""
+
+from prometheus_client import Counter, Gauge, start_http_server
+
+# Metric collectors
+ORDERS_TOTAL = Counter("orders_total", "Total orders processed", ["venue", "result"])
+PROFIT_TOTAL = Gauge("profit_total_usdt", "Realized profit in USDT", ["venue"])
 
 
-def start(port: int):
+def start_metrics_server(port: int) -> None:
+    """Start the Prometheus metrics server on the provided ``port``.
+
+    Parameters
+    ----------
+    port:
+        TCP port to bind the HTTP server to.
+    """
+
     start_http_server(port)


### PR DESCRIPTION
## Summary
- rename Prometheus metrics to `ORDERS_TOTAL` and `PROFIT_TOTAL`
- add `start_metrics_server` wrapper around `start_http_server`
- update CLI and docs to use new metrics and helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab843c17688329a9b76faa0e09261e