### PR TITLE
docs(core): add module and object docstrings

### DIFF
--- a/arbit/adapters/base.py
+++ b/arbit/adapters/base.py
@@ -2,8 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple
-from typing import Literal
+from typing import Any, Dict, Literal, Tuple
 
 Side = Literal["buy", "sell"]
 

--- a/arbit/adapters/base.py
+++ b/arbit/adapters/base.py
@@ -1,6 +1,8 @@
+"""Abstract interfaces for exchange adapters."""
+
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Tuple
 from dataclasses import dataclass
+from typing import Any, Dict, Tuple
 from typing import Literal
 
 Side = Literal["buy", "sell"]
@@ -8,6 +10,8 @@ Side = Literal["buy", "sell"]
 
 @dataclass
 class OrderSpec:
+    """Parameters required to create an order on an exchange."""
+
     symbol: str
     side: Side
     qty: float
@@ -16,15 +20,28 @@ class OrderSpec:
 
 
 class ExchangeAdapter(ABC):
+    """Interface that all exchange adapters must implement."""
+
     @abstractmethod
-    def name(self) -> str: ...
+    def name(self) -> str:
+        """Return exchange identifier used by this adapter."""
+
     @abstractmethod
-    def fetch_orderbook(self, symbol: str, depth: int = 10) -> Dict[str, Any]: ...
+    def fetch_orderbook(self, symbol: str, depth: int = 10) -> Dict[str, Any]:
+        """Fetch order book levels for *symbol* up to *depth*."""
+
     @abstractmethod
-    def fetch_fees(self, symbol: str) -> Tuple[float, float]: ...
+    def fetch_fees(self, symbol: str) -> Tuple[float, float]:
+        """Return ``(maker, taker)`` fee rates for *symbol*."""
+
     @abstractmethod
-    def min_notional(self, symbol: str) -> float: ...
+    def min_notional(self, symbol: str) -> float:
+        """Smallest allowed notional value for trading *symbol*."""
+
     @abstractmethod
-    def create_order(self, spec: OrderSpec): ...
+    def create_order(self, spec: OrderSpec):
+        """Submit an order defined by *spec* to the exchange."""
+
     @abstractmethod
-    def balances(self) -> Dict[str, float]: ...
+    def balances(self) -> Dict[str, float]:
+        """Return asset balances with non-zero amounts."""

--- a/arbit/config.py
+++ b/arbit/config.py
@@ -1,9 +1,13 @@
-from pydantic import BaseSettings, Field
+"""Configuration management and credential helpers."""
+
 from typing import List
-import os
+
+from pydantic import BaseSettings, Field
 
 
 class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
     env: str = "dev"
     log_level: str = "INFO"
     exchanges: List[str] = Field(default_factory=lambda: ["alpaca", "kraken"])
@@ -34,11 +38,13 @@ class Settings(BaseSettings):
         env_file = ".env"
 
 
+# Singleton settings instance populated on import.
 settings = Settings()
 
 
 def creds_for(ex_id: str) -> tuple[str | None, str | None]:
-    # Prefer per-venue; fall back to legacy ARBIT_* if present
+    """Return API credentials for *ex_id*, falling back to legacy values."""
+    # Prefer per-venue; fall back to legacy ARBIT_* if present.
     if ex_id == "alpaca":
         return (
             settings.alpaca_api_key or settings.arbit_api_key,


### PR DESCRIPTION
## Summary
- add module-level docstrings and Settings helper docs in configuration module
- document exchange adapter interfaces and ccxt implementation

## Testing
- `black arbit/config.py arbit/adapters/base.py arbit/adapters/ccxt_adapter.py`
- `pytest` *(fails: ImportError: cannot import name 'arb_cycles' from 'arbit.metrics.exporter')*


------
https://chatgpt.com/codex/tasks/task_e_68ab87c46f20832981e06adfd21239b0