### PR TITLE
chore(ci): add DeepSource coverage workflow

### DIFF
--- a/.deepsource.yml
+++ b/.deepsource.yml
@@ -1,0 +1,17 @@
+version: 1
+
+analyzers:
+  python:
+    runtime_version: "3.x.x"
+
+transformers:
+  - isort
+  - ruff
+  - black
+
+test_patterns:
+  - "tests/**"
+
+coverage:
+  reports:
+    - coverage.xml

--- a/.github/workflows/deepsource.yml
+++ b/.github/workflows/deepsource.yml
@@ -1,0 +1,31 @@
+name: DeepSource
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest coverage
+      - name: Run tests
+        run: |
+          coverage run -m pytest
+          coverage xml
+      - name: Upload coverage to DeepSource
+        uses: deepsourcelabs/test-coverage-action@v1
+        with:
+          dsn: ${{ secrets.DEEPSOURCE_DSN }}
+          coverage-file: coverage.xml
+          test-formatter: coverage-xml
+          key: python
+          fail-ci-on-error: true


### PR DESCRIPTION
## Summary
- add DeepSource configuration file
- run tests and upload coverage via GitHub Actions

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'arb_cycles' from 'arbit.metrics.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d6cbbac8329a9a13d6da57d9fcd