### PR TITLE
docs(tests): add missing docstrings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,9 @@
+"""Pytest configuration helpers.
+
+Ensure the project root is added to ``sys.path`` so test modules can import
+local packages without installation.
+"""
+
 import sys
 from pathlib import Path
 

--- a/tests/test_ccxt_adapter.py
+++ b/tests/test_ccxt_adapter.py
@@ -1,3 +1,5 @@
+"""Tests for the CCXT exchange adapter implementation."""
+
 import pytest
 
 ccxt = pytest.importorskip("ccxt")
@@ -7,12 +9,14 @@ from arbit.models import OrderSpec
 
 
 def test_initialization() -> None:
+    """Adapter initialization returns a configured client."""
     adapter = CCXTAdapter("alpaca", "k", "s")
     assert isinstance(adapter, ExchangeAdapter)
     assert adapter.client.id == "alpaca"
 
 
 def test_fetch_order_book(monkeypatch) -> None:
+    """Order books are retrieved via the underlying ccxt client."""
     adapter = CCXTAdapter("kraken", "k", "s")
 
     def fake_fetch_order_book(symbol: str) -> dict:
@@ -25,6 +29,7 @@ def test_fetch_order_book(monkeypatch) -> None:
 
 
 def test_create_order(monkeypatch) -> None:
+    """Order creation passes through to the ccxt client."""
     adapter = CCXTAdapter("alpaca", "k", "s")
 
     def fake_create_order(symbol, order_type, side, amount, price):
@@ -44,6 +49,7 @@ def test_create_order(monkeypatch) -> None:
 
 
 def test_cancel_order(monkeypatch) -> None:
+    """Cancellation requests are forwarded to the client."""
     adapter = CCXTAdapter("alpaca", "k", "s")
     called: dict[str, str] = {}
 
@@ -57,6 +63,7 @@ def test_cancel_order(monkeypatch) -> None:
 
 
 def test_fetch_balance(monkeypatch) -> None:
+    """Balance retrieval uses the underlying client API."""
     adapter = CCXTAdapter("kraken", "k", "s")
 
     def fake_fetch_balance() -> dict:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
+"""Configuration model tests."""
+
 import pytest
 
 
 def test_settings_env() -> None:
+    """Settings model loads environment variables when available."""
     pytest.skip("Settings model unavailable in test environment")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,10 +1,13 @@
+"""Database helper tests for persistence layer."""
+
 from datetime import datetime
 
 from arbit.models import Fill, Triangle
 from arbit.persistence import db
 
 
-def test_insert_triangle_and_fill():
+def test_insert_triangle_and_fill() -> None:
+    """Records can be inserted and retrieved from the database."""
     conn = db.init_db(":memory:")
     triangle = Triangle("BTC/USDT", "USDT/ETH", "BTC/ETH")
     t_id = db.insert_triangle(conn, triangle)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -19,6 +19,8 @@ from arbit.models import Triangle
 
 
 class DummyAdapter(ExchangeAdapter):
+    """Lightweight adapter stub used for executor tests."""
+
     def __init__(self, books):
         self.books = books
         self.orders: list[OrderSpec] = []
@@ -46,6 +48,7 @@ class DummyAdapter(ExchangeAdapter):
 
 
 def profitable_books() -> dict[str, dict[str, list[tuple[float, float]]]]:
+    """Return a set of books that yields a profitable cycle."""
     return {
         "ETH/USDT": {"asks": [(100.0, 10.0)], "bids": [(99.0, 10.0)]},
         "BTC/ETH": {"bids": [(0.1, 10.0)], "asks": [(0.2, 10.0)]},
@@ -54,12 +57,14 @@ def profitable_books() -> dict[str, dict[str, list[tuple[float, float]]]]:
 
 
 def unprofitable_books() -> dict[str, dict[str, list[tuple[float, float]]]]:
+    """Return books adjusted to make the cycle unprofitable."""
     data = profitable_books()
     data["BTC/USDT"] = {"bids": [(900.0, 10.0)], "asks": [(901.0, 10.0)]}
     return data
 
 
 def test_try_triangle_executes_on_profit() -> None:
+    """Arbitrage cycle executes when net edge exceeds threshold."""
     tri = Triangle("ETH/USDT", "BTC/ETH", "BTC/USDT")
     books = profitable_books()
     adapter = DummyAdapter(books)
@@ -70,6 +75,7 @@ def test_try_triangle_executes_on_profit() -> None:
 
 
 def test_try_triangle_skips_when_unprofitable() -> None:
+    """Cycle is skipped when estimated net edge is below threshold."""
     tri = Triangle("ETH/USDT", "BTC/ETH", "BTC/USDT")
     books = unprofitable_books()
     adapter = DummyAdapter(books)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,10 @@
+"""Basic dataclass model tests."""
+
 from arbit.models import Triangle, OrderSpec, Fill
 
 
 def test_triangle() -> None:
+    """Triangle dataclass exposes configured legs."""
     tri = Triangle("ETH/USDT", "BTC/ETH", "BTC/USDT")
     assert tri.leg_ab == "ETH/USDT"
     assert tri.leg_bc == "BTC/ETH"
@@ -9,12 +12,14 @@ def test_triangle() -> None:
 
 
 def test_order_spec() -> None:
+    """OrderSpec defaults to a limit order without price."""
     order = OrderSpec(symbol="ETH/USDT", side="buy", quantity=1.0)
     assert order.order_type == "limit"
     assert order.price is None
 
 
 def test_fill() -> None:
+    """Fill captures execution details from an order."""
     fill = Fill(
         order_id="1", symbol="ETH/USDT", side="buy", price=10.0, quantity=1.0, fee=0.1
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 """Basic dataclass model tests."""
 
-from arbit.models import Triangle, OrderSpec, Fill
+from arbit.models import Fill, OrderSpec, Triangle
 
 
 def test_triangle() -> None:

--- a/tests/test_triangle_helpers.py
+++ b/tests/test_triangle_helpers.py
@@ -6,16 +6,19 @@ from arbit.engine.triangle import net_edge_cycle, size_from_depth, top
 
 
 def test_top() -> None:
+    """Best bid/ask pair is returned and empty lists yield ``(None, None)``."""
     levels = [(1.0, 2.0), (0.9, 2.1)]
     assert top(levels) == (1.0, 2.0)
     assert top([]) == (None, None)
 
 
 def test_net_edge_cycle() -> None:
+    """Net edge multiplies each rate and subtracts one."""
     assert net_edge_cycle([1.0, 1.1, 1.2]) == pytest.approx(0.32)
 
 
 def test_size_from_depth() -> None:
+    """Smallest quantity across levels determines executable size."""
     levels = [(10.0, 20.0), (11.0, 5.0)]
     assert size_from_depth(levels) == 5.0
     assert size_from_depth([]) == 0.0


### PR DESCRIPTION
## Summary
- add module-level docstrings for various test helpers
- document key test classes and functions for clarity

## Testing
- `pytest tests/test_ccxt_adapter.py tests/test_config.py tests/test_models.py tests/test_executor.py tests/test_triangle_helpers.py tests/test_db.py` *(fails: AttributeError: type object 'Config' has no attribute 'env_prefix')*

------
https://chatgpt.com/codex/tasks/task_e_68abddcfab148329a0bbc4c6b05a030c