### PR TITLE
fix(config): inherit base settings config

### DIFF
--- a/arbit/config.py
+++ b/arbit/config.py
@@ -34,7 +34,9 @@ class Settings(BaseSettings):
     sqlite_path: str = "arbit.db"
     discord_webhook_url: str | None = None
 
-    class Config:
+    class Config(BaseSettings.Config):
+        """Pydantic settings configuration."""
+
         env_file = ".env"
 
 


### PR DESCRIPTION
## Summary
- ensure Settings.Config inherits BaseSettings.Config so env_prefix exists

## Testing
- `pytest`
- `ruff check arbit tests` *(fails: E402, F401, etc. in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68abdec1f2e08329898e4a2bbe5d5a33