### PR TITLE
docs: clarify run modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ and prints the estimated net return of the USDT→ETH→BTC→USDT cycle.
 
 ### Typer CLI
 
-A Typer-based interface exposes `fitness` and `live` commands:
+A Typer-based interface exposes `keys:check`, `fitness`, and `live` commands:
 
 ```bash
+python -m arbit.cli keys:check
 python -m arbit.cli fitness --venue alpaca --secs 5
-python -m arbit.cli live --venue alpaca --cycles 1
+python -m arbit.cli live --venue alpaca
 ```
 
-Both commands load credentials from environment variables (`ARBIT_API_KEY`,
-`ARBIT_API_SECRET`) and use them to connect via `ccxt`.
+Use `keys:check` to validate API credentials. `live` runs indefinitely and honours
+the `DRY_RUN` setting. All commands load credentials from environment variables
+(`ARBIT_API_KEY`, `ARBIT_API_SECRET`) and use them to connect via `ccxt`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,6 @@
-# -- MAIN ROADMAP FOR DEVELOPEMTN FEATURES
+# -- MAIN ROADMAP FOR DEVELOPMENT FEATURES
+
+Basic CLI `live` loop is operational via `python -m arbit.cli live`; runs in dry-run mode unless configured otherwise.
 
     kraken_api_key: str | None = None
     kraken_api_secret: str | None = None


### PR DESCRIPTION
## Summary
- document keys:check, fitness, and live CLI commands
- note operational live loop in roadmap and README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b615c8c83299ee44439c868695d