### PR TITLE
fix(typer): remove eval use

### DIFF
--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -21,7 +21,7 @@ class Typer(click.Group):
             for name, param in sig.parameters.items():
                 annotation = type_hints.get(name, param.annotation)
                 opt = click.Option(
-                    [f"--{name.replace('_','-')}"],
+                    [f"--{name.replace('_', '-')}"],
                     default=param.default,
                     type=annotation if annotation is not inspect._empty else str,
                 )

--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import inspect
+import typing
+
 import click
 
 
@@ -10,19 +12,24 @@ class Typer(click.Group):
     """Simplified Typer implementation based on Click."""
 
     def command(self, *args, **kwargs):  # type: ignore[override]
+        """Return a decorator registering a function as a CLI command."""
+
         def decorator(func):
             sig = inspect.signature(func)
+            type_hints = typing.get_type_hints(func, globalns=func.__globals__)
             params = []
             for name, param in sig.parameters.items():
+                annotation = type_hints.get(name, param.annotation)
                 opt = click.Option(
                     [f"--{name.replace('_','-')}"],
                     default=param.default,
-                    type=(eval(param.annotation, func.__globals__) if isinstance(param.annotation, str) else param.annotation) if param.annotation is not inspect._empty else str,
+                    type=annotation if annotation is not inspect._empty else str,
                 )
                 params.append(opt)
             cmd = click.Command(func.__name__, params=params, callback=func)
             self.add_command(cmd)
             return cmd
+
         return decorator
 
     def __call__(self, *args, **kwargs):  # pragma: no cover - passthrough


### PR DESCRIPTION
## Summary
- replace `eval` with `typing.get_type_hints` in minimal Typer implementation
- document command decorator

## Testing
- `python -m black --check typer/__init__.py`
- `ruff check typer/__init__.py`
- `isort --check-only typer/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abe7b598848329b138c222c1d3854c