### PR TITLE
fix(cli): handle missing BTC/USDT in keys_check

### DIFF
--- a/arbit/cli.py
+++ b/arbit/cli.py
@@ -50,7 +50,9 @@ def keys_check():
             symbol = (
                 "BTC/USDT"
                 if "BTC/USDT" in ms
-                else "BTC/USD" if "BTC/USD" in ms else next(iter(ms))
+                else "BTC/USD"
+                if "BTC/USD" in ms
+                else next(iter(ms))
             )
             ob = a.fetch_orderbook(symbol, 1)
             bid = ob.get("bids", [])

--- a/arbit/cli.py
+++ b/arbit/cli.py
@@ -42,14 +42,22 @@ def _build_adapter(venue: str, _settings=settings):
 
 @app.command("keys:check")
 def keys_check():
+    """Validate exchange credentials by fetching a sample order book."""
     for venue in settings.exchanges:
         try:
             a = _build_adapter(venue, settings)
             ms = a.ex.load_markets()
-            ob = a.fetch_orderbook("BTC/USDT", 1)
-            log.info(
-                f"[{venue}] markets={len(ms)} BTC/USDT {ob['bids'][0][0]}/{ob['asks'][0][0]}"
+            symbol = (
+                "BTC/USDT"
+                if "BTC/USDT" in ms
+                else "BTC/USD" if "BTC/USD" in ms else next(iter(ms))
             )
+            ob = a.fetch_orderbook(symbol, 1)
+            bid = ob.get("bids", [])
+            ask = ob.get("asks", [])
+            bid_price = bid[0][0] if bid else "n/a"
+            ask_price = ask[0][0] if ask else "n/a"
+            log.info(f"[{venue}] markets={len(ms)} {symbol} {bid_price}/{ask_price}")
         except Exception as e:
             log.error(f"[{venue}] ERROR: {e}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,12 +16,13 @@ sys.modules["arbit.config"] = types.SimpleNamespace(
         dry_run=True,
         net_threshold_bps=10.0,
         notional_per_trade_usd=200.0,
+        exchanges=["alpaca"],
     )
 )
 
 sys.modules["arbit.adapters.ccxt_adapter"] = types.SimpleNamespace(CcxtAdapter=object)
 
-from arbit import cli
+from arbit import cli  # noqa: E402
 
 
 class DummyAdapter:
@@ -72,6 +73,29 @@ def test_fitness(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(cli.app, ["fitness", "--secs", "1"])
     assert result.exit_code == 0
+
+
+def test_keys_check(monkeypatch):
+    class DummyCcxt:
+        """Minimal ccxt-like exchange for testing `keys_check`."""
+
+        @staticmethod
+        def load_markets() -> dict:
+            """Return available markets for the dummy exchange."""
+            return {"BTC/USD": {}}
+
+    class DummyKeyAdapter(DummyAdapter):
+        def __init__(self):
+            super().__init__()
+            self.ex = DummyCcxt()
+
+    adapter = DummyKeyAdapter()
+    monkeypatch.setattr(cli, "_build_adapter", lambda venue, _settings: adapter)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["keys_check"])
+    assert result.exit_code == 0
+    assert adapter.books_calls == ["BTC/USD"]
 
 
 def test_live() -> None:


### PR DESCRIPTION
## Summary
- choose a supported market symbol when verifying exchange keys
- test keys_check uses available market symbols
- make dummy exchange markets static in keys_check test

## Testing
- `ruff check arbit/cli.py tests/test_cli.py`
- `black arbit/cli.py tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abe66fa6dc8329ae11d1f1207be592