### PR TITLE
fix(stubs): avoid protected attribute access

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -17,10 +17,11 @@ class _Value:
     """Container for a single numeric metric value."""
 
     def __init__(self) -> None:
-        self._v = 0.0
+        self.value = 0.0
 
     def get(self) -> float:
-        return self._v
+        """Return the current metric value."""
+        return self.value
 
 
 class _Metric:
@@ -30,10 +31,12 @@ class _Metric:
         self._value = _Value()
 
     def inc(self, amount: float = 1.0) -> None:  # pragma: no cover - trivial
-        self._value._v += amount
+        """Increase the metric by *amount*."""
+        self._value.value += amount
 
     def set(self, value: float) -> None:  # pragma: no cover - trivial
-        self._value._v = value
+        """Set the metric to *value*."""
+        self._value.value = value
 
 
 Counter = Gauge = _Metric

--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -23,10 +23,9 @@ class Typer(click.Group):
                 opt = click.Option(
                     [f"--{name.replace('_', '-')}"],
                     default=param.default,
-                    type=
-                        annotation
-                        if annotation is not inspect.Signature.empty
-                        else str,
+                    type=(
+                        annotation if annotation is not inspect.Signature.empty else str
+                    ),
                 )
                 params.append(opt)
             cmd = click.Command(func.__name__, params=params, callback=func)

--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -23,7 +23,10 @@ class Typer(click.Group):
                 opt = click.Option(
                     [f"--{name.replace('_', '-')}"],
                     default=param.default,
-                    type=annotation if annotation is not inspect._empty else str,
+                    type=
+                        annotation
+                        if annotation is not inspect.Signature.empty
+                        else str,
                 )
                 params.append(opt)
             cmd = click.Command(func.__name__, params=params, callback=func)


### PR DESCRIPTION
## Summary
- avoid protected attribute in Typer command by using `inspect.Signature.empty`
- expose metric value via public attribute and document helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae9b1594dc8329b7fdeef07a2c17cc