### PR TITLE
chore(docker): pin Python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 RUN pip install --no-cache-dir \
-    ccxt \
-    websockets \
-    pydantic \
-    typer \
-    prometheus-client \
-    orjson
+    ccxt==4.1.79 \
+    websockets==11.0.3 \
+    pydantic==1.10.9 \
+    typer==0.9.0 \
+    prometheus-client==0.17.1 \
+    orjson==3.9.5
 
 COPY arbit ./arbit
 


### PR DESCRIPTION
## Summary
- pin package versions in Dockerfile for reproducible builds

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae9b81f360832986b72b58c2a54aef