### PR TITLE
refactor(stubs): clarify no-op implementations

### DIFF
--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -51,7 +51,8 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def log_message(self, *_args, **_kwargs) -> None:  # pragma: no cover - quiet
-        pass
+        """Override to silence the default request logging."""
+        return None
 
 
 def start_http_server(port: int) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,10 +41,12 @@ class DummyAdapter:
         return books.get(symbol, {"bids": [], "asks": []})
 
     def create_order(self, *args, **kwargs):  # pragma: no cover - not used
-        pass
+        """Stubbed order creation used solely for interface compatibility."""
+        return None
 
     def cancel_order(self, *args, **kwargs):  # pragma: no cover - not used
-        pass
+        """Stubbed order cancellation used solely for interface compatibility."""
+        return None
 
     @staticmethod
     def fetch_balance(*args, **kwargs) -> float:  # pragma: no cover
@@ -64,7 +66,8 @@ def test_fitness(monkeypatch):
             return self.t
 
         def sleep(self, _secs: float) -> None:
-            pass
+            """Advance the fake clock without real delay."""
+            return None
 
     monkeypatch.setattr(cli, "time", _Time())
 


### PR DESCRIPTION
## Summary
- silence `_Handler` request logging with explicit no-op implementation
- document no-op test stubs for adapter methods and fake sleep

## Testing
- `python -m black /workspace/Arbit/prometheus_client/__init__.py /workspace/Arbit/tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef621969c8329a645a71830125050