### PR TITLE
fix(config): strip quotes in env loader

### DIFF
--- a/arbit/config.py
+++ b/arbit/config.py
@@ -19,7 +19,9 @@ def _load_env_file(path: str = ".env") -> None:
 
     The implementation is intentionally minimal to avoid depending on external
     packages such as :mod:`python-dotenv`. Lines starting with ``#`` or lacking
-    an ``=`` separator are ignored. Existing keys are not overwritten.
+    an ``=`` separator are ignored. Existing keys are not overwritten. Values
+    wrapped in single or double quotes are unquoted to match typical ``.env``
+    file behavior.
     """
 
     try:
@@ -28,6 +30,11 @@ def _load_env_file(path: str = ".env") -> None:
             if not line or line.startswith("#") or "=" not in line:
                 continue
             key, value = line.split("=", 1)
+            value = value.strip()
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                value = value[1:-1]
             os.environ.setdefault(key, value)
     except FileNotFoundError:
         # It's fine if the .env file is absent; environment variables may be

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import sys
 
 
@@ -27,3 +28,19 @@ def test_exchanges_json(monkeypatch):
 def test_exchanges_csv(monkeypatch):
     cfg = _load_with_exchanges(monkeypatch, "alpaca, kraken")
     assert cfg.settings.exchanges == ["alpaca", "kraken"]
+
+
+def test_load_env_file_strips_quotes(monkeypatch, tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text('FOO="bar"\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("FOO", raising=False)
+    original = sys.modules.get("arbit.config")
+    sys.modules.pop("arbit.config", None)
+    importlib.import_module("arbit.config")
+    assert os.environ["FOO"] == "bar"
+    if original is not None:
+        sys.modules["arbit.config"] = original
+    else:
+        sys.modules.pop("arbit.config", None)
+    monkeypatch.delenv("FOO", raising=False)


### PR DESCRIPTION
## Summary
- strip surrounding quotes when loading `.env` file values
- document env loader behavior and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af02c099d083299808f5fed6e4b810