### PR TITLE
feat(cli): add verbose help for spread and net

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ python -m arbit.cli fitness --venue kraken --secs 20
 python -m arbit.cli fitness --venue alpaca --secs 5
 ```
 
+Typical log line: ``kraken ETH/USDT spread=0.5 bps`` where ``spread`` is the
+best ask minus best bid expressed in basis points (1 bps = 0.01%). Smaller
+spreads generally indicate deeper liquidity. Use ``--help-verbose`` for more
+output guidance.
+
 ### Live Trading (⚠️ PLACES REAL ORDERS)
 
 **WARNING**: Only use with tiny amounts and proper risk management!
@@ -152,6 +157,12 @@ python -m arbit.cli live --venue alpaca
 # With different venue
 python -m arbit.cli live --venue kraken
 ```
+
+A typical execution log looks like
+``alpaca Triangle(ETH/USDT, ETH/BTC, BTC/USDT) net=0.15% PnL=0.05 USDT``.
+Here ``net`` denotes the estimated profit after fees for the triangle and
+``PnL`` shows realized profit in USDT. Invoke the command with
+``--help-verbose`` to see these explanations from the CLI itself.
 
 ### Monitoring & Metrics
 

--- a/legacy_arbit.py
+++ b/legacy_arbit.py
@@ -78,12 +78,14 @@ def run_loop(
             time.sleep(0.2)
             continue
 
-        net = compute_net(ask_ab, bid_bc, bid_ac)
+        net = compute_net(ask_ab, bid_bc, bid_ac)  # estimated profit after fees
         if net >= THRESH:
             usdt = min(QTY_USDT, ask_ab * ob_ab["asks"][0][1])
-            message = f"Arb! est_net={net:.4%} notional≈${usdt:.2f}"
+            message = (
+                f"Arb! est_net={net:.4%} (est. profit after fees) notional≈${usdt:.2f}"
+            )
         else:
-            message = f"net={net:.4%}"
+            message = f"net={net:.4%} (est. profit after fees)"
 
         if screen:
             screen.erase()


### PR DESCRIPTION
## Summary
- explain spread and net figures in CLI and legacy script logs
- add `--help-verbose` option to fitness and live commands
- document sample log lines for fitness and live in README

## Testing
- `ruff check legacy_arbit.py arbit/cli.py`
- `pytest -q` *(fails: TypeError: 'NoneType' object is not callable in tests/test_ccxt_adapter.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b934142e20832984fd4f8f5f4189b7