### PR TITLE
fix(metrics): import missing start_http_server

### DIFF
--- a/arbit/metrics/exporter.py
+++ b/arbit/metrics/exporter.py
@@ -4,7 +4,7 @@ This module exposes counters and gauges for tracking orders and profit as well a
 utilities for starting the metrics HTTP server.
 """
 
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge, Histogram, start_http_server
 
 # Metric collectors
 ORDERS_TOTAL = Counter("orders_total", "Total orders processed", ["venue", "result"])


### PR DESCRIPTION
## Summary
- fix exporter metrics server by importing `start_http_server`

## Testing
- `black arbit/metrics/exporter.py`
- `ruff check arbit/metrics/exporter.py`
- `pytest -q` *(fails: 'NoneType' object is not callable in CCXTAdapter)*

------
https://chatgpt.com/codex/tasks/task_e_68b931e6a154832989eb5215d51179b5