### PR TITLE
docs(cli): document modes and verbose help

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Arbit monitors triangular arbitrage opportunities across cryptocurrency exchange
 - **Docker support** with multi-venue deployment
 - **Supported exchanges**: Alpaca, Kraken (via CCXT)
 
+### CLI Modes at a Glance
+
+| Mode        | Purpose                                                         | Example log line                             |
+|-------------|-----------------------------------------------------------------|----------------------------------------------|
+| `fitness`   | Read-only spread sampling to verify connectivity                | `kraken ETH/USDT spread=0.5 bps`             |
+| `live`      | Execute trades when triangles meet profit thresholds            | `alpaca Triangle(...) net=0.15% PnL=0.05`    |
+| `keys:check`| Validate exchange keys and permissions                          | `[alpaca] markets=123 BTC/USDT 60000/60010`  |
+
+Run `python -m arbit.cli --help-verbose` for command flags and more output samples.
+
 See [WARP.md](WARP.md) for comprehensive documentation, architecture details, and development roadmap.
 
 ## Quick Start

--- a/WARP.md
+++ b/WARP.md
@@ -51,8 +51,15 @@ pytest -q
 ```
 
 ### CLI Commands
-- Fitness sampling (read-only): `python -m arbit.cli fitness --venue kraken --secs 20`
-- Live trading cycles: `python -m arbit.cli live --venue alpaca --cycles 5 --metrics-port 9109`
+
+| Mode        | Purpose                                                         | Example log line                             |
+|-------------|-----------------------------------------------------------------|----------------------------------------------|
+| `fitness`   | Read-only spread sampling to verify connectivity                | `kraken ETH/USDT spread=0.5 bps`             |
+| `live`      | Execute trades when triangles meet profit thresholds            | `alpaca Triangle(...) net=0.15% PnL=0.05`    |
+| `keys:check`| Validate exchange keys and permissions                          | `[alpaca] markets=123 BTC/USDT 60000/60010`  |
+
+Run `python -m arbit.cli --help-verbose` for command flags and additional output samples.
+
 - Deprecated legacy TUI (monitor-only): `python deprecated/legacy_arbit.py --tui` (use `python -m arbit.cli` instead)
 
 ### Configuration


### PR DESCRIPTION
## Summary
- Add CLI mode summary table for `fitness`, `live`, and `keys:check`
- Reference `--help-verbose` for deeper command explanations in docs

## Testing
- `pytest -q` *(fails: TypeError: 'NoneType' object is not callable in tests/test_ccxt_adapter.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b95aa0bb9c83299cfec930be6c8657