### PR TITLE
docs: streamline project roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,106 +1,8 @@
-# WARP.md
+# ROADMAP
 
-This file provides guidance to WARP (warp.dev) when working with code in this repository.
+This document outlines current capabilities and future plans for the Arbit triangular arbitrage system.
 
-# Arbit Triangular Arbitrage System
-
-This repository contains a modular Python package for triangular arbitrage trading on cryptocurrency exchanges, with CLI interface, metrics, SQLite persistence, Docker support, and optional DeFi integration.
-
-## TLDR Quickstart
-
-```bash
-python -m venv .venv
-source .venv/bin/activate      # Windows: .venv\Scripts\activate
-python -m pip install -U pip
-pip install ccxt pydantic typer prometheus-client orjson websockets pytest
-
-# Set credentials for your chosen venue
-export ARBIT_API_KEY=your_venue_specific_key
-export ARBIT_API_SECRET=your_venue_specific_secret
-
-# Read-only connectivity test
-python -m arbit.cli fitness --venue kraken --secs 10
-
-# Live trading loop with metrics (⚠️  places real orders)
-python -m arbit.cli live --venue alpaca --cycles 1 --metrics-port 9109
-
-# Check metrics
-curl http://localhost:9109/metrics
-```
-
-**Notes:**
-- Use `fitness` command for safe read-only testing.
-- The `live` command can place real orders - use with caution.
-- Optional legacy TUI available in `legacy_arbit.py`.
-
-## Development Workflow
-
-### Virtual Environment
-```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -U pip
-pip install ccxt pydantic typer prometheus-client orjson websockets pytest
-# Optional for DeFi integration:
-pip install web3
-```
-
-### Running Tests
-```bash
-pytest -q
-```
-
-### CLI Commands
-- Fitness sampling (read-only): `python -m arbit.cli fitness --venue kraken --secs 20`
-- Live trading cycles: `python -m arbit.cli live --venue alpaca --cycles 5 --metrics-port 9109`
-- Legacy TUI (monitor-only): `python legacy_arbit.py --tui`
-
-### Configuration
-The system uses Pydantic Settings with environment prefix `ARBIT_`:
-- `ARBIT_API_KEY`, `ARBIT_API_SECRET`: Exchange credentials
-- `ARBIT_NET_THRESHOLD`: Minimum net return threshold (default: 0.001)
-- `ARBIT_DATA_DIR`: Data directory (default: ./data)
-- `ARBIT_LOG_PATH`: Log file path (default: ./arbit.log)
-
-### Platform-Specific Notes
-- Ensure data directory exists: `mkdir -p data`
-- Windows legacy TUI dependency: `pip install windows-curses`
-- Deactivate venv: `deactivate`
-
-## Configuration and Environment
-
-### Modern CLI Configuration
-The system uses `arbit.config.Settings` (Pydantic) with environment prefix `ARBIT_` and `.env` support.
-
-**Core Environment Variables:**
-```bash
-# Exchange credentials (used by CCXT)
-ARBIT_API_KEY=your_venue_api_key
-ARBIT_API_SECRET=your_venue_api_secret
-
-# Trading parameters
-ARBIT_NET_THRESHOLD=0.001  # minimum net return threshold
-ARBIT_DATA_DIR=./data      # directory for SQLite and logs
-ARBIT_LOG_PATH=./arbit.log # log file path
-```
-
-**DeFi Integration (Aave) Environment Variables:**
-```bash
-# Required for stake.py
-RPC_URL=https://your-rpc-endpoint
-PRIVATE_KEY=0x...
-ARBIT_USDC_ADDRESS=0x...   # chain-specific USDC contract
-ARBIT_POOL_ADDRESS=0x...   # Aave v3 Pool contract
-ARBIT_USDC_ABI_PATH=erc20.json      # default
-ARBIT_POOL_ABI_PATH=aave_pool.json  # default
-```
-
-**Docker Environment Mapping:**
-In `docker-compose.yml`, per-venue keys are mapped:
-- Alpaca service: `ARBIT_API_KEY=${ARBIT_ALPACA_API_KEY}`
-- Kraken service: `ARBIT_API_KEY=${ARBIT_KRAKEN_API_KEY}`
-
-Refer to `.env.example` for complete configuration template.
+For installation and configuration guidance, see [README](README.md) or [WARP.md](WARP.md).
 
 ## What Ships Today
 
@@ -215,26 +117,26 @@ net   = gross * (1 - fee)^3 - 1
 ## Development Roadmap
 
 ### Phase 1 (MVP Weekend)
-- ✅ ccxt REST monitor with TUI
-- ✅ Single triangle, single exchange
-- ✅ Estimates only, no execution
-- 🔄 Optional: Aave USDC deposit utility
+ - [x] ccxt REST monitor with TUI
+ - [x] Single triangle, single exchange
+ - [x] Estimates only, no execution
+ - [ ] Optional: Aave USDC deposit utility
 
 ### Phase 2 (Production Ready)
-- WebSocket order books for reduced latency
-- Multi-symbol rotation and inventory rebalancing  
-- Prometheus metrics and monitoring
-- Dry-run execution mode → controlled live trading
-- Strict notional caps and IOC-only orders
-- Automated stablecoin allocator with thresholds
+ - [ ] WebSocket order books for reduced latency
+ - [ ] Multi-symbol rotation and inventory rebalancing
+ - [ ] Prometheus metrics and monitoring
+ - [ ] Dry-run execution mode for controlled live trading
+ - [ ] Strict notional caps and IOC-only orders
+ - [ ] Automated stablecoin allocator with thresholds
 
 ### Phase 3 (Multi-Exchange)
-- Cross-exchange arbitrage routing
-- Hedger logic for risk management
-- Robust error handling and recovery
-- Idempotent operations with client IDs
-- Production alerting and monitoring
-- Full containerization and deployment automation
+ - [ ] Cross-exchange arbitrage routing
+ - [ ] Hedger logic for risk management
+ - [ ] Robust error handling and recovery
+ - [ ] Idempotent operations with client IDs
+ - [ ] Production alerting and monitoring
+ - [ ] Full containerization and deployment automation
 
 ## Safety and Risk Management
 
@@ -308,24 +210,3 @@ A: Estimates assume perfect execution at top-of-book prices. Real trading involv
 - **Legacy**: `legacy_arbit.py`
 - **Tests**: `tests/test_triangle.py`
 
-## Common Development Commands
-
-```bash
-# Quick connectivity test
-python -m arbit.cli fitness --venue kraken --secs 5
-
-# Live (caution: may place orders)
-python -m arbit.cli live --venue alpaca --cycles 1 --metrics-port 9109
-
-# Run unit tests
-pytest -q
-
-# Check available exchanges in ccxt
-python -c "import ccxt; print(sorted(ccxt.exchanges)[:10])"
-
-# Clean venv and reinstall deps
-rm -rf .venv && python -m venv .venv && source .venv/bin/activate && pip install -U pip && pip install ccxt pydantic typer prometheus-client orjson websockets pytest web3
-
-# Docker up both venues
-docker compose up -d --build
-```


### PR DESCRIPTION
## Summary
- rename roadmap header and remove quickstart/configuration sections
- add checklists for phase milestones and link to README/WARP.md for setup

## Testing
- `pytest -q` *(fails: CCXTAdapter is None due to missing ccxt dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ac6111148329986cf86966ddee15