### PR TITLE
feat: modular Discord webhook notifier

### DIFF
--- a/arbit/notify.py
+++ b/arbit/notify.py
@@ -1,0 +1,54 @@
+"""Notification helpers for external services.
+
+Currently supports sending simple messages to a Discord webhook. The helpers
+are intentionally lightweight so that other modules can reuse them without
+rewriting webhook logic.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Optional
+
+from .config import settings
+from .metrics.exporter import ERRORS_TOTAL
+
+
+def notify_discord(venue: str, message: str, url: Optional[str] = None) -> None:
+    """Send *message* to a Discord webhook.
+
+    Parameters
+    ----------
+    venue:
+        Name of the venue or subsystem issuing the notification. Used for
+        labeling error metrics.
+    message:
+        Text content to send to Discord.
+    url:
+        Optional override for the webhook URL. Defaults to
+        ``settings.discord_webhook_url``.
+
+    Notes
+    -----
+    Any network or configuration errors are swallowed so that notification
+    failures never interrupt trading flows. When an error occurs, the
+    ``errors_total`` metric is incremented with stage ``discord_send``.
+    """
+
+    webhook = url or getattr(settings, "discord_webhook_url", None)
+    if not webhook:
+        return
+
+    data = json.dumps({"content": message}).encode("utf-8")
+    req = urllib.request.Request(
+        webhook, data=data, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=3):
+            return
+    except Exception:
+        try:
+            ERRORS_TOTAL.labels(venue, "discord_send").inc()
+        except Exception:
+            pass

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from types import SimpleNamespace
+
+from arbit import notify
+
+
+def test_notify_discord_noop_when_url_missing(monkeypatch):
+    """notify_discord should return quietly when no webhook is configured."""
+    monkeypatch.setattr(notify, "settings", SimpleNamespace(discord_webhook_url=None))
+    with patch("urllib.request.urlopen") as mock_open:
+        notify.notify_discord("test", "hello")
+    assert mock_open.call_count == 0
+
+
+def test_notify_discord_sends_with_url(monkeypatch):
+    """notify_discord should attempt a network call when URL is set."""
+    monkeypatch.setattr(
+        notify,
+        "settings",
+        SimpleNamespace(discord_webhook_url="https://example.com"),
+    )
+    with patch("urllib.request.urlopen") as mock_open:
+        notify.notify_discord("test", "hi")
+        assert mock_open.call_count == 1
+        req = mock_open.call_args.args[0]
+        assert req.full_url == "https://example.com"


### PR DESCRIPTION
## Summary
- add `notify_discord` helper for reusable Discord webhook notifications
- refactor CLI to use notifier for yield actions and heartbeats
- cover notifier behavior with unit tests

## Testing
- `ruff check arbit/notify.py arbit/cli.py tests/test_notify.py --fix`
- `black arbit/notify.py arbit/cli.py tests/test_notify.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe10aa9788329b498d8a0ceed0c67