### PR TITLE
feat(adapters): add load_markets interface

### DIFF
--- a/arbit/adapters/alpaca_adapter.py
+++ b/arbit/adapters/alpaca_adapter.py
@@ -224,7 +224,7 @@ class AlpacaAdapter(ExchangeAdapter):
 
     # ------------------------------------------------------------------
     def load_markets(self) -> Dict[str, Dict[str, Any]]:
-        """Return available trading symbols (pairs)."""
+        """Return mapping of tradeable pairs via the Alpaca REST API."""
 
         if self._markets is not None:
             return self._markets

--- a/arbit/adapters/base.py
+++ b/arbit/adapters/base.py
@@ -34,6 +34,10 @@ class ExchangeAdapter(ABC):
         """Return ``(maker, taker)`` fee rates for *symbol*."""
 
     @abstractmethod
+    def load_markets(self) -> Dict[str, Dict[str, Any]]:
+        """Return mapping of market symbol to metadata."""
+
+    @abstractmethod
     def min_notional(self, symbol: str) -> float:
         """Smallest allowed notional value for trading *symbol*."""
 

--- a/arbit/adapters/ccxt_adapter.py
+++ b/arbit/adapters/ccxt_adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import AsyncGenerator, Iterable
+from typing import Any, AsyncGenerator, Dict, Iterable
 
 import ccxt
 
@@ -146,6 +146,11 @@ class CCXTAdapter(ExchangeAdapter):
         taker = m.get("taker", self.ex.fees.get("trading", {}).get("taker", 0.001))
         self._fee[symbol] = (maker, taker)
         return maker, taker
+
+    def load_markets(self) -> Dict[str, Dict[str, Any]]:
+        """Return market metadata from the underlying ``ccxt`` client."""
+
+        return self.ex.load_markets()
 
     def min_notional(self, symbol):
         """Return exchange-imposed minimum notional for *symbol*."""

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -42,6 +42,11 @@ class DummyAdapter(ExchangeAdapter):
     def min_notional(self, symbol: str) -> float:  # pragma: no cover - simple stub
         return 0.0
 
+    def load_markets(
+        self,
+    ) -> dict[str, dict[str, float]]:  # pragma: no cover - simple stub
+        return {s: {"symbol": s} for s in self.books.keys()}
+
     def create_order(self, spec: OrderSpec):
         book = self.books[spec.symbol]
         price = book["asks"][0][0] if spec.side == "buy" else book["bids"][0][0]


### PR DESCRIPTION
## Summary
- expose abstract `load_markets` method on `ExchangeAdapter`
- forward `load_markets` in `CCXTAdapter`
- document Alpaca market loading via REST API

## Testing
- `python -m black Arbit/arbit/adapters/base.py Arbit/arbit/adapters/ccxt_adapter.py Arbit/arbit/adapters/alpaca_adapter.py Arbit/tests/test_executor.py`
- `python -m ruff check Arbit/arbit/adapters/base.py Arbit/arbit/adapters/ccxt_adapter.py Arbit/arbit/adapters/alpaca_adapter.py Arbit/tests/test_executor.py`
- `python -m mypy Arbit/arbit/adapters/base.py Arbit/arbit/adapters/ccxt_adapter.py Arbit/arbit/adapters/alpaca_adapter.py Arbit/tests/test_ccxt_adapter.py` *(fails: missing type stubs in dependencies)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64ca8dbfc8329882bb4ab4cbd4197