### PR TITLE
refactor: support AlpacaAdapter without ccxt-specific calls

### DIFF
--- a/arbit/adapters/__init__.py
+++ b/arbit/adapters/__init__.py
@@ -1,4 +1,6 @@
-"""Exchange adapter interfaces and implementations."""
+"""Exchange adapter interfaces and implementations.
+
+Exports adapters for CCXT-supported venues and Alpaca's native API."""
 
 from .base import ExchangeAdapter
 


### PR DESCRIPTION
## Summary
- route Alpaca venues through AlpacaAdapter
- use adapter.load_markets and remove direct ccxt client access
- document available adapter implementations

## Testing
- `pre-commit run --files arbit/cli.py arbit/adapters/__init__.py` *(command not found)*
- `python -m black arbit/cli.py arbit/adapters/__init__.py` *(ModuleNotFoundError: No module named 'click.core')*
- `ruff check arbit/cli.py arbit/adapters/__init__.py`
- `pytest -q` *(ImportError: cannot import name 'ContractName' from 'eth_typing')*

------
https://chatgpt.com/codex/tasks/task_e_68c672bdc7688329848a9d39ec4ab2ee