### PR TITLE
feat(config): add Alpaca websocket URL and dependency

### DIFF
--- a/arbit/config.py
+++ b/arbit/config.py
@@ -60,6 +60,8 @@ class Settings(BaseSettings):
     alpaca_api_key: str | None = None
     alpaca_api_secret: str | None = None
     alpaca_base_url: str = "https://api.alpaca.markets"
+    # Websocket endpoint for crypto order book streams.
+    alpaca_ws_crypto_url: str = "wss://stream.data.alpaca.markets/v1beta3/crypto/us"
 
     kraken_api_key: str | None = None
     kraken_api_secret: str | None = None

--- a/arbit/requirements.txt
+++ b/arbit/requirements.txt
@@ -4,3 +4,4 @@ pydantic==1.10.13
 stake==0.11.0
 typer==0.17.4
 web3==6.20.1
+alpaca-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ typer==0.9.0
 prometheus-client==0.19.0
 orjson==3.9.15
 web3==6.20.1
+alpaca-py

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,6 +170,9 @@ def test_keys_check(monkeypatch):
             super().__init__()
             self.ex = DummyCcxt()
 
+        def load_markets(self) -> dict:
+            return self.ex.load_markets()
+
     adapter = DummyKeyAdapter()
     monkeypatch.setattr(cli, "_build_adapter", lambda venue, _settings: adapter)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,3 +44,13 @@ def test_load_env_file_strips_quotes(monkeypatch, tmp_path):
     else:
         sys.modules.pop("arbit.config", None)
     monkeypatch.delenv("FOO", raising=False)
+
+
+def test_creds_for_alpaca(monkeypatch) -> None:
+    """``creds_for`` should pull venue-specific keys when available."""
+
+    monkeypatch.setenv("ALPACA_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_API_SECRET", "secret")
+    sys.modules.pop("arbit.config", None)
+    cfg = importlib.import_module("arbit.config")
+    assert cfg.creds_for("alpaca") == ("key", "secret")

--- a/tests/test_z_alpaca_adapter.py
+++ b/tests/test_z_alpaca_adapter.py
@@ -55,7 +55,9 @@ def test_orderbook_stream_reconnect(monkeypatch) -> None:
     monkeypatch.setattr(
         aa, "settings", SimpleNamespace(alpaca_base_url="", alpaca_map_usdt_to_usd=True)
     )
-    adapter = aa.AlpacaAdapter("k", "s")
+    monkeypatch.setattr(aa, "creds_for", lambda ex: ("k", "s"))
+    adapter = aa.AlpacaAdapter()
+    assert adapter._key == "k" and adapter._secret == "s"
 
     async def run() -> None:
         gen = adapter.orderbook_stream(["BTC/USDT"], depth=1, reconnect_delay=0)


### PR DESCRIPTION
## Summary
- add alpaca-py to package requirements
- expose configurable Alpaca websocket URL
- test that `creds_for('alpaca')` supplies credentials

## Testing
- `black tests/test_config.py tests/test_z_alpaca_adapter.py arbit/config.py`
- `ruff check tests/test_config.py tests/test_z_alpaca_adapter.py arbit/config.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ac19274483298e3e50e332dd2eda