### PR TITLE
feat(engine): add market triangle discovery

### DIFF
--- a/arbit/cli.py
+++ b/arbit/cli.py
@@ -16,6 +16,9 @@ import typer
 from arbit.adapters import AlpacaAdapter, CCXTAdapter, ExchangeAdapter
 from arbit.config import settings
 from arbit.engine.executor import stream_triangles, try_triangle
+from arbit.engine.triangle import (
+    discover_triangles_from_markets as _discover_triangles_from_markets,
+)
 from arbit.metrics.exporter import (
     CYCLE_LATENCY,
     FILLS_TOTAL,
@@ -489,7 +492,7 @@ async def _live_run_for_venue(
         suggestions: list[list[str]] = []
         try:
             ms = a.load_markets()
-            suggestions = _discover_triangles_from_markets(ms)[:3]  # noqa: F821
+            suggestions = _discover_triangles_from_markets(ms)[:3]
         except Exception:
             suggestions = []
         # If requested, auto-use top-N suggestions for this session only
@@ -1255,9 +1258,7 @@ def keys_check():
             symbol = (
                 "BTC/USDT"
                 if "BTC/USDT" in ms
-                else "BTC/USD"
-                if "BTC/USD" in ms
-                else next(iter(ms))
+                else "BTC/USD" if "BTC/USD" in ms else next(iter(ms))
             )
             ob = a.fetch_orderbook(symbol, 1)
             bid = ob.get("bids", [])
@@ -1527,7 +1528,7 @@ def config_discover(
     except Exception as e:
         log.error("load_markets failed for %s: %s", venue, e)
         raise SystemExit(1)
-    triples = _discover_triangles_from_markets(ms)  # noqa: F821
+    triples = _discover_triangles_from_markets(ms)
     typer.echo(
         f"{venue} triangles={len(triples)} "
         + (f"first={'|'.join(triples[0])}" if triples else "")
@@ -1961,7 +1962,7 @@ def live(
             suggestions: list[list[str]] = []
             try:
                 ms = a.load_markets()
-                suggestions = _discover_triangles_from_markets(ms)[:3]  # noqa: F821
+                suggestions = _discover_triangles_from_markets(ms)[:3]
             except Exception:
                 suggestions = []
             # If requested, auto-use top-N suggestions for this session only

--- a/arbit/engine/__init__.py
+++ b/arbit/engine/__init__.py
@@ -3,6 +3,17 @@
 from __future__ import annotations
 
 from .executor import try_triangle
-from .triangle import net_edge, size_from_depth, top
+from .triangle import (
+    discover_triangles_from_markets,
+    net_edge,
+    size_from_depth,
+    top,
+)
 
-__all__ = ["top", "net_edge", "size_from_depth", "try_triangle"]
+__all__ = [
+    "top",
+    "net_edge",
+    "size_from_depth",
+    "discover_triangles_from_markets",
+    "try_triangle",
+]

--- a/tests/test_triangle_discovery.py
+++ b/tests/test_triangle_discovery.py
@@ -1,0 +1,24 @@
+from arbit.engine.triangle import discover_triangles_from_markets
+
+
+def test_discover_triangles_basic():
+    ms = {
+        "ETH/USDT": {"base": "ETH", "quote": "USDT"},
+        "ETH/BTC": {"base": "ETH", "quote": "BTC"},
+        "BTC/USDT": {"base": "BTC", "quote": "USDT"},
+    }
+    assert discover_triangles_from_markets(ms) == [["ETH/USDT", "ETH/BTC", "BTC/USDT"]]
+
+
+def test_discover_triangles_multiple_and_parse_symbol():
+    ms = {
+        "ETH/USDT": {},
+        "ETH/BTC": {},
+        "BTC/USDT": {},
+        "ETH/USDC": {},
+        "BTC/USDC": {},
+    }
+    tris = discover_triangles_from_markets(ms)
+    assert ["ETH/USDT", "ETH/BTC", "BTC/USDT"] in tris
+    assert ["ETH/USDC", "ETH/BTC", "BTC/USDC"] in tris
+    assert len(tris) == 2


### PR DESCRIPTION
## Summary
- add `discover_triangles_from_markets` to enumerate A/B, A/C, C/B market cycles
- expose triangle discovery via engine package and CLI utilities
- cover triangle discovery logic with unit tests

## Testing
- `ruff check arbit/engine/triangle.py arbit/engine/__init__.py arbit/cli.py tests/test_triangle_discovery.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: tests/test_cli.py::test_keys_check)*


------
https://chatgpt.com/codex/tasks/task_e_68c6b0a8eedc8329a744bc7d8bc2059d