### PR TITLE
docs: note native Alpaca API and config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Rationale: Tight spreads on `DAI/USDT` and `ETH/USDT` with generally adequate de
 - **SQLite persistence** for trade history
 - **Docker support** with multi-venue deployment
 - **WebSocket streaming** with automatic REST fallback
-- **Supported exchanges**: Alpaca, Kraken (via CCXT)
+- **Supported exchanges**: Alpaca (native API), Kraken (via CCXT)
 
 ### CLI Modes at a Glance
 
@@ -81,7 +81,7 @@ See [WARP.md](WARP.md) for comprehensive documentation, architecture details, an
 python -m venv .venv
 source .venv/bin/activate      # Windows: .venv\Scripts\activate
 python -m pip install -U pip
-pip install ccxt pydantic typer prometheus-client orjson websockets pytest
+pip install alpaca-py ccxt pydantic typer prometheus-client orjson websockets pytest
 
 # Configure API credentials (see Configuration section below)
 export ARBIT_API_KEY=your_venue_api_key
@@ -110,7 +110,7 @@ python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 
 # Install dependencies
-pip install ccxt pydantic typer prometheus-client orjson websockets pytest
+pip install alpaca-py ccxt pydantic typer prometheus-client orjson websockets pytest
 
 # Optional: DeFi integration
 pip install web3
@@ -155,6 +155,8 @@ For multiple exchanges, use venue-specific variables:
 export ALPACA_API_KEY=your_alpaca_key
 export ALPACA_API_SECRET=your_alpaca_secret
 export ALPACA_BASE_URL=https://paper-api.alpaca.markets  # Paper trading
+export ALPACA_WS_CRYPTO_URL=wss://stream.data.alpaca.markets/v1beta3/crypto/us  # optional
+export ALPACA_MAP_USDT_TO_USD=true  # treat /USDT pairs as /USD
 
 # Kraken
 export KRAKEN_API_KEY=your_kraken_key
@@ -236,6 +238,24 @@ Prometheus metrics are exposed on port 9109 by default:
 curl http://localhost:9109/metrics
 
 # Key metrics: orders_total, fills_total, profit_total_usdt
+```
+
+### WebSocket Streaming Example
+
+Stream live order books with the native Alpaca adapter:
+
+```python
+import asyncio
+from arbit.adapters.alpaca_adapter import AlpacaAdapter
+
+async def main():
+    adapter = AlpacaAdapter()
+    async for sym, book in adapter.orderbook_stream(["BTC/USDT"], depth=1):
+        print(sym, book)
+        break
+    await adapter.close()
+
+asyncio.run(main())
 ```
 
 **Supported Venues**: `alpaca`, `kraken`
@@ -369,8 +389,8 @@ See [WARP.md Troubleshooting](WARP.md#common-issues-and-troubleshooting) for det
 **Q: Does this place actual trades?**
 A: `fitness` is read-only. `live` **WILL place real orders** if keys have trading permissions.
 
-**Q: Which exchanges are supported?**  
-A: Currently Alpaca and Kraken via CCXT. More exchanges can be added.
+**Q: Which exchanges are supported?**
+A: Currently Alpaca (native API) and Kraken via CCXT. More exchanges can be added.
 
 **Q: How accurate are profit estimates?**
 A: Estimates assume perfect execution at top-of-book prices. Real trading involves slippage, fees, and partial fills.
@@ -390,7 +410,7 @@ This README provides user-focused documentation. For comprehensive technical det
 
 ## Acknowledgments
 
-Built with [CCXT](https://github.com/ccxt/ccxt) for exchange connectivity, [Pydantic](https://pydantic-docs.helpmanual.io/) for configuration, and [Typer](https://typer.tiangolo.com/) for CLI interface.
+Built with [alpaca-py](https://github.com/alpacahq/alpaca-py) for native Alpaca connectivity, [CCXT](https://github.com/ccxt/ccxt) for other exchanges, [Pydantic](https://pydantic-docs.helpmanual.io/) for configuration, and [Typer](https://typer.tiangolo.com/) for CLI interface.
 
 ---
 

--- a/arbit/cli.py
+++ b/arbit/cli.py
@@ -166,6 +166,9 @@ class CLIApp(typer.Typer):
             ]
             alias_str = f" (aliases: {', '.join(sorted(aliases))})" if aliases else ""
             typer.echo(f"  {cname:<12} {desc}{alias_str}")
+        typer.echo(
+            "\nExchanges: alpaca (native API via alpaca-py) and kraken (via CCXT)."
+        )
         typer.echo("\nTip: run --help-verbose for flags and examples.")
 
     # ------------------------------------------------------------------
@@ -175,6 +178,7 @@ class CLIApp(typer.Typer):
 
         typer.echo("Command reference:\n")
         typer.echo("Global: --help (short list), --help-verbose (this view)\n")
+        typer.echo("Exchanges: alpaca (native API via alpaca-py), kraken (via CCXT)\n")
 
         typer.echo(
             "keys:check\n"
@@ -383,8 +387,8 @@ def _build_adapter(venue: str, _settings=settings) -> ExchangeAdapter:
     Returns
     -------
     ExchangeAdapter
-        ``AlpacaAdapter`` when *venue* is ``"alpaca"`` otherwise
-        ``CCXTAdapter``.
+        ``AlpacaAdapter`` using Alpaca's native ``alpaca-py`` clients when
+        *venue* is ``"alpaca"``; otherwise ``CCXTAdapter``.
     """
 
     if venue.lower() == "alpaca":


### PR DESCRIPTION
## Summary
- clarify that Alpaca now uses its native `alpaca-py` API instead of ccxt
- document new Alpaca configuration options and dependency requirements
- add websocket streaming example and CLI help notes

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b996ee788329b735f07e4cb4d10f