### PR TITLE
docs: add config recommend guidance

### DIFF
--- a/TIPS_TRICKS.html
+++ b/TIPS_TRICKS.html
@@ -109,6 +109,7 @@
       <li><a href="#database-signals-for-performance-debugging"> - Database Signals</a></li>
       <li><a href="#safety-operational-tips"> - Safety &amp; Operational Tips</a></li>
       <li><a href="#interpreting-marketslimits-output"> - Interpreting markets:limits</a></li>
+      <li><a href="#baseline-config-with-configrecommend"> - Baseline Config with <code>config:recommend</code></a></li>
       <li><a href="#extending-this-guide"> - Extending This Guide</a></li>
     </ul>
   </nav>
@@ -453,6 +454,15 @@
         <li>Flags marked in help as “optional” are not required; some only apply when specific modes are enabled (e.g.,
           <code>--persist</code> is only relevant with <code>--simulate</code>).
         </li>
+      </ul>
+    </section>
+    <section>
+      <h2 id="baseline-config-with-configrecommend">Baseline Config with <code>config:recommend</code></h2>
+      <ul>
+        <li>Run <code>python -m arbit.cli config:recommend --venue &lt;venue&gt;</code> to print sample Strategy settings.</li>
+        <li>Copy the suggested values into <code>.env</code> and adjust for your risk tolerance.</li>
+        <li>Review <code>NOTIONAL_PER_TRADE_USD</code> and fee assumptions before going live.</li>
+        <li>Re-run after venue fee changes or when switching markets.</li>
       </ul>
     </section>
     <section>

--- a/TIPS_TRICKS.md
+++ b/TIPS_TRICKS.md
@@ -13,6 +13,7 @@ This guide collects practical advice for configuring and operating Arbit safely,
 - [Database Signals for Performance Debugging](#database-signals-for-performance-debugging)
 - [Safety & Operational Tips](#safety--operational-tips)
 - [Interpreting `markets:limits` Output](#interpreting-marketslimits-output)
+- [Baseline Config with `config:recommend`](#baseline-config-with-configrecommend)
 - [Extending This Guide](#extending-this-guide)
 
 ## Quick Recommendations
@@ -214,6 +215,13 @@ Aliases and Flags
   - `markets:limits` (preferred) or `markets_limits`
   - `config:recommend` (preferred) or `config_recommend`
 - Flags marked in help as “optional” are not required; some only apply when specific modes are enabled (e.g., `--persist` is only relevant with `--simulate`).
+
+## Baseline Config with `config:recommend`
+
+- Run `python -m arbit.cli config:recommend --venue <venue>` to print sample Strategy settings.
+- Copy the suggested values into `.env` and adjust for your risk tolerance.
+- Review `NOTIONAL_PER_TRADE_USD` and fee assumptions before going live.
+- Re-run after venue fee changes or when switching markets.
 
 ## Extending This Guide
 


### PR DESCRIPTION
## Summary
- document how to generate baseline settings with `config:recommend`
- mirror update in HTML tips guide

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6dc117e048329a99af29699f6fe4a