### PR TITLE
Add Kraken promo helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ curl http://localhost:9109/metrics
 
 💡 **First time?** Use `fitness` command first to verify connectivity. See [WARP.md](WARP.md) for detailed explanations and safety practices.
 
+### Kraken Promotion Helper
+
+Need to complete Kraken's "$20 in BTC" welcome promo that requires at least $50 in trading volume on a non-stablecoin asset? The Typer helper below plans a qualifying trade and defaults to a safe dry run:
+
+```bash
+# Preview the plan (no orders placed)
+python -m arbit.promo.kraken trade --usd-amount 55 --base ETH --quote USD
+
+# Execute the trade once you're ready
+export DRY_RUN=false  # required for live orders
+python -m arbit.promo.kraken trade --usd-amount 55 --base ETH --quote USD --execute
+```
+
+Key safeguards:
+
+- Rejects stablecoin bases (e.g., USDC, USDT) so the trade qualifies.
+- Verifies the notional exceeds $50 after rounding to Kraken's lot size.
+- Sells the asset back to the quote currency by default to keep exposure flat (use `--hold` to keep it).
+- Requires both `--execute` **and** `DRY_RUN=false` to place real orders.
+
 ## Installation
 
 **Requirements:** Python 3.10+ recommended

--- a/arbit/promo/__init__.py
+++ b/arbit/promo/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for exchange-specific promotional workflows."""
+
+__all__ = ["kraken"]

--- a/arbit/promo/kraken.py
+++ b/arbit/promo/kraken.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_DOWN
+from decimal import ROUND_DOWN, Decimal
 from typing import Any, Mapping
 
 import typer
-
 from arbit.adapters.base import OrderSpec
 from arbit.adapters.ccxt_adapter import CCXTAdapter
 from arbit.config import settings
@@ -264,12 +263,16 @@ def promo_trade(
 
     adapter = CCXTAdapter("kraken")
     try:
-        plan = plan_trade(adapter, base, quote, _to_decimal(usd_amount), orderbook_depth=depth)
+        plan = plan_trade(
+            adapter, base, quote, _to_decimal(usd_amount), orderbook_depth=depth
+        )
         typer.echo(_format_plan(plan))
 
         result = execute_plan(adapter, plan, execute=execute, sell_back=sell_back)
         if result.dry_run:
-            typer.echo("Dry run complete. Re-run with --execute and DRY_RUN=false to trade.")
+            typer.echo(
+                "Dry run complete. Re-run with --execute and DRY_RUN=false to trade."
+            )
         else:
             typer.echo(
                 f"Buy order id={result.buy.get('id')} qty={result.buy.get('qty')} price={result.buy.get('price')}"

--- a/arbit/promo/kraken.py
+++ b/arbit/promo/kraken.py
@@ -1,0 +1,299 @@
+"""Safely execute a Kraken trade to satisfy promotional volume requirements."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_DOWN
+from typing import Any, Mapping
+
+import typer
+
+from arbit.adapters.base import OrderSpec
+from arbit.adapters.ccxt_adapter import CCXTAdapter
+from arbit.config import settings
+
+LOGGER = logging.getLogger(__name__)
+
+STABLE_ASSETS = {
+    "USDT",
+    "USDC",
+    "DAI",
+    "BUSD",
+    "USDP",
+    "TUSD",
+    "GUSD",
+    "PAX",
+    "USD",
+    "EUR",
+    "GBP",
+    "CHF",
+    "AUD",
+    "CAD",
+    "JPY",
+}
+"""Assets treated as stable for promotion eligibility checks."""
+
+PROMO_MIN_NOTIONAL = Decimal("50")
+"""Minimum USD notional required to qualify for the Kraken promotion."""
+
+FUDGE_FACTOR = Decimal("1.002")
+"""Increase applied before rounding to remain above the promotional threshold."""
+
+app = typer.Typer(help="Kraken promotion helper that defaults to a safe dry run.")
+
+
+@dataclass
+class TradePlan:
+    """Container describing the intended Kraken trade."""
+
+    symbol: str
+    base: str
+    quote: str
+    usd_target: Decimal
+    ask_price: Decimal
+    bid_price: Decimal
+    quantity: Decimal
+    notional: Decimal
+
+    def spread_bps(self) -> Decimal:
+        """Return the bid/ask spread in basis points."""
+
+        if self.ask_price == 0:
+            return Decimal(0)
+        return (self.ask_price - self.bid_price) / self.ask_price * Decimal("10000")
+
+
+@dataclass
+class ExecutionResult:
+    """Summary of submitted Kraken orders."""
+
+    buy: Mapping[str, Any] | None
+    sell: Mapping[str, Any] | None
+    dry_run: bool
+
+
+class PromoError(RuntimeError):
+    """Raised when the promo workflow cannot continue safely."""
+
+
+def is_stable_asset(asset: str) -> bool:
+    """Return ``True`` when *asset* is considered stable."""
+
+    return asset.upper() in STABLE_ASSETS
+
+
+def _to_decimal(value: Any) -> Decimal:
+    """Convert *value* to :class:`~decimal.Decimal` preserving precision."""
+
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float, str)):
+        return Decimal(str(value))
+    raise TypeError(f"Unsupported numeric value: {value!r}")
+
+
+def _apply_precision(quantity: Decimal, market: Mapping[str, Any]) -> Decimal:
+    """Round *quantity* down to comply with market precision settings."""
+
+    precision = market.get("precision", {}).get("amount")
+    if precision is not None:
+        try:
+            precision = int(precision)
+            if precision >= 0:
+                step = Decimal(1).scaleb(-precision)
+                quantity = quantity.quantize(step, rounding=ROUND_DOWN)
+        except Exception as exc:  # pragma: no cover - defensive path
+            raise PromoError(f"Invalid amount precision: {precision}") from exc
+    return quantity
+
+
+def _validate_amount_bounds(quantity: Decimal, market: Mapping[str, Any]) -> None:
+    """Ensure *quantity* satisfies the market's minimum trade size."""
+
+    min_amount = market.get("limits", {}).get("amount", {}).get("min")
+    if min_amount:
+        min_amount_dec = _to_decimal(min_amount)
+        if quantity < min_amount_dec:
+            raise PromoError(
+                "Calculated quantity is below Kraken's minimum amount. "
+                "Increase the USD amount or choose a different asset."
+            )
+
+
+def plan_trade(
+    adapter: CCXTAdapter,
+    base: str,
+    quote: str,
+    usd_amount: Decimal,
+    *,
+    orderbook_depth: int = 5,
+) -> TradePlan:
+    """Generate a :class:`TradePlan` for a Kraken promo trade."""
+
+    base = base.upper()
+    quote = quote.upper()
+    usd_amount = usd_amount.quantize(Decimal("0.01"))
+
+    if usd_amount <= PROMO_MIN_NOTIONAL:
+        raise PromoError("USD amount must be greater than $50.00 to qualify.")
+
+    markets = adapter.load_markets()
+    symbol = f"{base}/{quote}"
+    market = markets.get(symbol)
+    if not market:
+        raise PromoError(f"Symbol {symbol} is not available on Kraken.")
+
+    if is_stable_asset(market.get("base", base)):
+        raise PromoError(
+            f"{base} is classified as a stable asset. Choose a non-stable asset."
+        )
+
+    min_notional = _to_decimal(adapter.min_notional(symbol))
+    if min_notional > usd_amount:
+        raise PromoError(
+            "Kraken's minimum notional exceeds the requested USD amount. "
+            "Increase --usd-amount to proceed."
+        )
+
+    orderbook = adapter.fetch_orderbook(symbol, orderbook_depth)
+    asks = orderbook.get("asks") or []
+    bids = orderbook.get("bids") or []
+    if not asks or not bids:
+        raise PromoError("Order book depth is insufficient to plan the trade.")
+
+    ask_price = _to_decimal(asks[0][0])
+    bid_price = _to_decimal(bids[0][0])
+    if ask_price <= 0:
+        raise PromoError("Invalid ask price returned by Kraken.")
+
+    raw_qty = usd_amount / ask_price
+    padded_qty = raw_qty * FUDGE_FACTOR
+    quantity = _apply_precision(padded_qty, market)
+    _validate_amount_bounds(quantity, market)
+
+    notional = (quantity * ask_price).quantize(Decimal("0.01"))
+    if notional <= PROMO_MIN_NOTIONAL:
+        raise PromoError(
+            "Rounded trade size falls below the $50 requirement. Increase the "
+            "USD amount or try again when spreads are tighter."
+        )
+
+    return TradePlan(
+        symbol=symbol,
+        base=base,
+        quote=quote,
+        usd_target=usd_amount,
+        ask_price=ask_price,
+        bid_price=bid_price,
+        quantity=quantity,
+        notional=notional,
+    )
+
+
+def execute_plan(
+    adapter: CCXTAdapter,
+    plan: TradePlan,
+    *,
+    execute: bool,
+    sell_back: bool,
+) -> ExecutionResult:
+    """Submit the promo trade described by *plan* if ``execute`` is true."""
+
+    if not execute:
+        return ExecutionResult(buy=None, sell=None, dry_run=True)
+
+    if settings.dry_run:
+        raise PromoError(
+            "DRY_RUN is enabled. Export DRY_RUN=false to allow live trading."
+        )
+
+    buy_spec = OrderSpec(symbol=plan.symbol, side="buy", qty=float(plan.quantity))
+    LOGGER.info(
+        "Submitting Kraken buy order symbol=%s qty=%s", plan.symbol, plan.quantity
+    )
+    buy_fill = adapter.create_order(buy_spec)
+
+    sell_fill: Mapping[str, Any] | None = None
+    if sell_back:
+        sell_qty = _to_decimal(buy_fill.get("qty", plan.quantity))
+        if sell_qty > 0:
+            sell_spec = OrderSpec(symbol=plan.symbol, side="sell", qty=float(sell_qty))
+            LOGGER.info(
+                "Submitting Kraken sell order symbol=%s qty=%s", plan.symbol, sell_qty
+            )
+            sell_fill = adapter.create_order(sell_spec)
+        else:
+            LOGGER.warning("Buy fill returned zero quantity; skipping sell leg.")
+
+    return ExecutionResult(buy=buy_fill, sell=sell_fill, dry_run=False)
+
+
+def _format_plan(plan: TradePlan) -> str:
+    """Return a human-readable summary for *plan*."""
+
+    return (
+        f"Kraken promo plan → buy {plan.quantity} {plan.base} at ~{plan.ask_price} {plan.quote} "
+        f"(notional ≈ ${plan.notional}). Spread ≈ {plan.spread_bps():.2f} bps."
+    )
+
+
+@app.command("trade")
+def promo_trade(
+    base: str = typer.Option("ETH", help="Non-stable asset to purchase."),
+    quote: str = typer.Option("USD", help="Quote currency to spend."),
+    usd_amount: float = typer.Option(
+        55.0, help="USD amount to spend. Must exceed $50 to qualify."
+    ),
+    depth: int = typer.Option(5, help="Order book depth used for planning."),
+    sell_back: bool = typer.Option(
+        True, "--sell-back/--hold", help="Sell the asset back to the quote currency."
+    ),
+    execute: bool = typer.Option(
+        False, "--execute", help="Submit live orders when DRY_RUN=false."
+    ),
+    log_level: str = typer.Option("INFO", help="Logging level for script output."),
+) -> None:
+    """Plan and optionally execute a Kraken trade for the BTC promo."""
+
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    adapter = CCXTAdapter("kraken")
+    try:
+        plan = plan_trade(adapter, base, quote, _to_decimal(usd_amount), orderbook_depth=depth)
+        typer.echo(_format_plan(plan))
+
+        result = execute_plan(adapter, plan, execute=execute, sell_back=sell_back)
+        if result.dry_run:
+            typer.echo("Dry run complete. Re-run with --execute and DRY_RUN=false to trade.")
+        else:
+            typer.echo(
+                f"Buy order id={result.buy.get('id')} qty={result.buy.get('qty')} price={result.buy.get('price')}"
+            )
+            if result.sell:
+                typer.echo(
+                    f"Sell order id={result.sell.get('id')} qty={result.sell.get('qty')} price={result.sell.get('price')}"
+                )
+            else:
+                typer.echo("Sell leg skipped; asset retained.")
+    except PromoError as exc:
+        LOGGER.error("Promo trade failed: %s", exc)
+        raise typer.Exit(code=1) from exc
+    finally:
+        try:
+            asyncio.run(adapter.close())
+        except RuntimeError:
+            LOGGER.debug("Event loop already running; closing adapter synchronously.")
+            try:
+                if hasattr(adapter, "ex") and hasattr(adapter.ex, "close"):
+                    adapter.ex.close()
+            except Exception:
+                LOGGER.debug("Failed to close ccxt client cleanly.")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    app()

--- a/tests/test_kraken_promo.py
+++ b/tests/test_kraken_promo.py
@@ -1,0 +1,124 @@
+"""Tests for the Kraken promotional trading helper."""
+
+from decimal import Decimal
+
+import pytest
+
+from arbit.promo.kraken import (
+    ExecutionResult,
+    PromoError,
+    TradePlan,
+    execute_plan,
+    is_stable_asset,
+    plan_trade,
+)
+
+
+class DummyAdapter:
+    """Minimal adapter stub for exercising promo logic."""
+
+    def __init__(self) -> None:
+        self._markets = {
+            "ETH/USD": {
+                "base": "ETH",
+                "quote": "USD",
+                "precision": {"amount": 5},
+                "limits": {"amount": {"min": 0.0001}},
+            }
+        }
+        self._orderbook = {
+            "asks": [[2000.0, 1.0]],
+            "bids": [[1999.5, 1.0]],
+        }
+        self._min_notional = 5.0
+        self.orders = []
+
+    def load_markets(self):
+        return self._markets
+
+    def min_notional(self, symbol):
+        return self._min_notional
+
+    def fetch_orderbook(self, symbol, depth):
+        return self._orderbook
+
+    def create_order(self, spec):
+        self.orders.append(spec)
+        side_price = 2000.0 if spec.side == "buy" else 1999.5
+        return {
+            "id": f"{spec.side}-{len(self.orders)}",
+            "symbol": spec.symbol,
+            "side": spec.side,
+            "price": side_price,
+            "qty": spec.qty,
+            "fee": 0.0,
+        }
+
+
+def test_is_stable_asset_detection():
+    """Stable asset detection should be case insensitive."""
+
+    assert is_stable_asset("usdt")
+    assert not is_stable_asset("eth")
+
+
+def test_plan_trade_generates_valid_plan(monkeypatch):
+    """Planning a trade should return a notional comfortably above $50."""
+
+    adapter = DummyAdapter()
+    plan = plan_trade(adapter, "eth", "usd", Decimal("55"))
+    assert isinstance(plan, TradePlan)
+    assert plan.base == "ETH"
+    assert plan.quote == "USD"
+    assert plan.notional > Decimal("50")
+    assert plan.quantity > 0
+
+
+def test_plan_trade_rejects_stable_asset(monkeypatch):
+    """Stable coins must not be considered eligible base assets."""
+
+    adapter = DummyAdapter()
+    adapter._markets["USDC/USD"] = {
+        "base": "USDC",
+        "quote": "USD",
+        "precision": {"amount": 5},
+        "limits": {"amount": {"min": 0.0001}},
+    }
+    with pytest.raises(PromoError):
+        plan_trade(adapter, "usdc", "usd", Decimal("55"))
+
+
+def test_plan_trade_requires_over_fifty_dollars():
+    """Amounts at or below $50 should be rejected."""
+
+    adapter = DummyAdapter()
+    with pytest.raises(PromoError):
+        plan_trade(adapter, "eth", "usd", Decimal("50"))
+
+
+def test_execute_plan_respects_dry_run(monkeypatch):
+    """Live execution should be blocked while dry run mode is enabled."""
+
+    from arbit.config import settings
+
+    adapter = DummyAdapter()
+    plan = plan_trade(adapter, "eth", "usd", Decimal("55"))
+    monkeypatch.setattr(settings, "dry_run", True)
+    with pytest.raises(PromoError):
+        execute_plan(adapter, plan, execute=True, sell_back=True)
+
+
+def test_execute_plan_places_orders_when_live(monkeypatch):
+    """When dry run is disabled the helper should submit buy and sell orders."""
+
+    from arbit.config import settings
+
+    adapter = DummyAdapter()
+    plan = plan_trade(adapter, "eth", "usd", Decimal("55"))
+    monkeypatch.setattr(settings, "dry_run", False)
+    result = execute_plan(adapter, plan, execute=True, sell_back=True)
+    assert isinstance(result, ExecutionResult)
+    assert not result.dry_run
+    assert len(adapter.orders) == 2
+    assert result.buy["side"] == "buy"
+    assert result.sell["side"] == "sell"


### PR DESCRIPTION
## Summary
- add a Typer-based helper under `arbit.promo.kraken` that plans and executes the $50 Kraken promo trade with safety checks
- document the new helper and usage safeguards in the README
- cover the planner and execution helpers with unit tests using a stub adapter

## Testing
- PYENV_VERSION=3.11.12 pytest tests/test_kraken_promo.py -q *(fails: ModuleNotFoundError: No module named 'ccxt')*
- PYENV_VERSION=3.11.12 pytest -q *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68c9ca0028688329aacb985006af8b14