### PR TITLE
feat: add command-scoped verbose help

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ Rationale: `USDC/USDT` and `ETH/USDC` are typically very liquid on Kraken with t
 | `live`      | Execute trades when triangles meet profit thresholds            | `alpaca Triangle(...) net=0.15% PnL=0.05`    |
 | `keys:check`| Validate exchange keys and permissions                          | `[alpaca] markets=123 BTC/USDT 60000/60010`  |
 
-Run `python -m arbit.cli --help-verbose` for command flags and more output samples.
+Run `python -m arbit.cli --help-verbose` for the full catalog, or append
+`--help-verbose` to a command (for example, `python -m arbit.cli fitness --help-verbose`)
+to drill into a single command's flags, sample output, and operational tips.
 
 ### CLI Help
 
-- Global: `--help` (summary), `--help-verbose` (all flags + examples)
+- Global: `--help` (summary), `--help-verbose` (detailed catalog or command-specific when appended)
 - `fitness` flags: `--venue`, `--secs`, `--simulate/--no-simulate`, `--persist/--no-persist`, `--dummy-trigger`, `--help-verbose`
 - `live` flags: `--venue`, `--help-verbose`
 - `live:multi` flags: `--venues`, `--symbols`, `--auto-suggest-top`

--- a/TIPS_TRICKS.html
+++ b/TIPS_TRICKS.html
@@ -145,8 +145,9 @@
         database if <code>--persist</code> is also specified.</p>
       <h3>CLI Help Quick Reference</h3>
       <ul>
-        <li>Global help: <code>python -m arbit.cli --help</code> (summary) or <code>--help-verbose</code> (all flags +
-          examples)</li>
+        <li>Global help: <code>python -m arbit.cli --help</code> (summary) or <code>--help-verbose</code> (full catalog).
+          Append <code>--help-verbose</code> to any command for focused tips (for example,
+          <code>python -m arbit.cli live --help-verbose</code>).</li>
         <li>Fitness flags: <code>--venue</code>, <code>--secs</code>, <code>--simulate/--no-simulate</code>,
           <code>--persist/--no-persist</code>, <code>--dummy-trigger</code>, <code>--help-verbose</code>
         </li>

--- a/TIPS_TRICKS.md
+++ b/TIPS_TRICKS.md
@@ -41,7 +41,8 @@ database if `--persist` is also specified.
 
 ### CLI Help Quick Reference
 
-- Global help: `python -m arbit.cli --help` (summary) or `--help-verbose` (all flags + examples)
+- Global help: `python -m arbit.cli --help` (summary) or `--help-verbose` (full catalog). Append
+  `--help-verbose` to any command for focused tips (e.g., `python -m arbit.cli live --help-verbose`).
 - Fitness flags: `--venue`, `--secs`, `--simulate/--no-simulate`, `--persist/--no-persist`, `--dummy-trigger`, `--help-verbose`
 - Live flags: `--venue`, `--help-verbose`
 - Yield (beta): `yield:collect --asset USDC --reserve-usd <USD> [--min-stake <units>]`; requires `RPC_URL`/`PRIVATE_KEY`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,6 +227,21 @@ def test_help_verbose_shows_details() -> None:
     assert "Sample output" in result.output
 
 
+def test_command_help_verbose_filters_sections() -> None:
+    """`COMMAND --help-verbose` should show only that command's verbose help."""
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["fitness", "--help-verbose"])
+    assert result.exit_code == 0
+    assert "Monitor bid/ask spreads" in result.output
+    assert "live:multi" not in result.output
+
+    alias_result = runner.invoke(cli.app, ["live_multi", "--help-verbose"])
+    assert alias_result.exit_code == 0
+    assert "live:multi" in alias_result.output
+    assert "markets:limits" not in alias_result.output
+
+
 def test_markets_limits(monkeypatch):
     class DummyCcxt:
         @staticmethod


### PR DESCRIPTION
## Summary
- add a shared verbose help catalog and update the CLI entrypoint to surface command-scoped help when `--help-verbose` follows a command
- update CLI commands that expose `--help-verbose` to reuse the shared renderer so the behaviour matches programmatic calls
- refresh README/TIPS docs and extend the CLI tests to cover the new command-specific help behaviour

## Testing
- /usr/bin/python3 -m pytest -q *(fails: No module named pytest in container)*
- /usr/bin/python3 -m compileall arbit/cli.py

------
https://chatgpt.com/codex/tasks/task_e_68ca317f926c8329b40898026f156cf3