### PR TITLE
feat: allow fee overrides for ccxt venues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ ARBIT_API_SECRET=
 # Strategy
 NOTIONAL_PER_TRADE_USD=200
 NET_THRESHOLD_BPS=10
+# Optional: override CCXT maker/taker fees per symbol (basis points JSON)
+# FEE_OVERRIDES={"kraken":{"ETH/USDT":{"taker_bps":0,"maker_bps":0}}}
 MAX_SLIPPAGE_BPS=8
 MAX_OPEN_ORDERS=3
 DRY_RUN=true

--- a/README.md
+++ b/README.md
@@ -198,6 +198,26 @@ export MAX_BOOK_AGE_MS=1500
 export REFRESH_ON_STALE=true
 # Min gap between refreshes per symbol (ms)
 export STALE_REFRESH_MIN_GAP_MS=150
+
+### Fee overrides for CCXT venues
+
+Most CCXT exchanges expose maker/taker tiers through their metadata, but some
+accounts qualify for custom discounts (e.g., promotional or volume-based
+pricing). Set ``FEE_OVERRIDES`` with a JSON blob to supply per-venue, per-symbol
+fees in basis points so Arbit's net calculation matches your tier:
+
+```bash
+export FEE_OVERRIDES='{"kraken":{"ETH/USDT":{"taker_bps":0,"maker_bps":0},"BTC/USDT":{"taker_bps":5}}}'
+```
+
+The keys are lowercase venues and uppercase symbols. ``maker_bps``/``taker_bps``
+accept numbers in basis points (``5`` → ``0.0005``). You can also provide
+decimal ``maker``/``taker`` fields if you already know the fraction. Optional
+``"*"`` entries apply to every symbol on the venue.
+
+💡 **Tip:** zero-fee tiers radically improve the net estimate. Reduce
+``NET_THRESHOLD_BPS`` to keep the execution guard realistic once overrides are
+in place.
 ```
 
 ### Per-Venue Configuration

--- a/TIPS_TRICKS.md
+++ b/TIPS_TRICKS.md
@@ -106,6 +106,9 @@ Below are the Strategy settings and how to think about each. Defaults are chosen
 - Recommendations:
   - Typical taker fee ≈ 10 bps per leg → fees are already netted in; set threshold to add buffer for slippage and latency.
   - Start `15–30 bps` (0.15–0.30%). For very volatile markets, use `30–50 bps`.
+  - If you configure `FEE_OVERRIDES` to reflect discounted or zero taker fees,
+    revisit the threshold immediately—zero-fee tiers can support much smaller
+    guards (e.g., `5–10 bps`).
   - Revisit after you have empirical skip/realized PnL data.
 
 ### `MAX_SLIPPAGE_BPS`


### PR DESCRIPTION
## Summary
- normalise FEE_OVERRIDES input in arbit.config.Settings so maker/taker basis-point maps are available as decimals
- consult the configured overrides in CCXTAdapter.fetch_fees before falling back to ccxt metadata
- document the JSON format and threshold guidance in README/.env.example/TIPS_TRICKS and add tests covering settings parsing and executor net behaviour

## Testing
- PYENV_VERSION=3.11.12 pytest tests/test_config.py tests/test_executor.py -k "not cli"

------
https://chatgpt.com/codex/tasks/task_e_68ca5514ed3883298c47c273ac35dd81