### PR TITLE
feat: surface attempt counters in CLI notifications

### DIFF
--- a/arbit/cli/commands/fitness.py
+++ b/arbit/cli/commands/fitness.py
@@ -34,7 +34,14 @@ def fitness(
     ),
     help_verbose: bool = False,
 ) -> None:
-    """Read-only sanity check that prints bid/ask spreads."""
+    """Read-only sanity check that prints bid/ask spreads.
+
+    Notes
+    -----
+    Discord notifications and CLI logs emitted per attempt now include the
+    cumulative attempt counter to help operators correlate simulation
+    cadence with downstream metrics.
+    """
 
     if help_verbose:
         app.print_verbose_help_for("fitness")
@@ -254,7 +261,10 @@ def fitness(
                                     )[:200]
                                     notify_discord(
                                         venue,
-                                        f"[fitness@{venue}] attempt SKIP {tri} reasons={reasons_summary}",
+                                        (
+                                            f"[fitness@{venue}] attempt#{attempts_total} "
+                                            f"SKIP {tri} reasons={reasons_summary}"
+                                        ),
                                     )
                                 except Exception:
                                     pass
@@ -278,8 +288,10 @@ def fitness(
                                 else None
                             )
                             msg = (
-                                f"[fitness@{venue}] attempt OK {tri} net={result['net_est'] * 100:.2f}% "
+                                f"[fitness@{venue}] attempt#{attempts_total} OK {tri} "
+                                f"net={result['net_est'] * 100:.2f}% "
                                 f"pnl={result['realized_usdt']:.4f} USDT "
+                                f"sim_trades_total={sim_count} "
                             )
                             if qty is not None:
                                 msg += f"qty={qty:.6g} "
@@ -325,8 +337,9 @@ def fitness(
                             except Exception:
                                 pass
                     log.info(
-                        "%s [sim] %s net=%.3f%% PnL=%.2f USDT",
+                        "%s [sim] attempt#%d %s net=%.3f%% PnL=%.2f USDT",
                         venue,
+                        attempts_total,
                         tri,
                         result.get("net_est", 0.0) * 100.0,
                         result.get("realized_usdt", 0.0),

--- a/tests/test_cli_fitness_attempts.py
+++ b/tests/test_cli_fitness_attempts.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import arbit.cli.commands.fitness as fitness_mod
+
+
+class _FakeClock:
+    """Simple monotonic clock used to control time progression in tests."""
+
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def time(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def test_fitness_attempt_logs_include_counters(monkeypatch, caplog):
+    """Per-attempt Discord and CLI logs should include attempt counters."""
+
+    clock = _FakeClock()
+    monkeypatch.setattr(fitness_mod.time, "time", clock.time)
+    monkeypatch.setattr(fitness_mod.time, "sleep", clock.sleep)
+
+    class DummyAdapter:
+        def fetch_orderbook(self, _symbol: str, _depth: int) -> dict:
+            return {"bids": [[1.0, 1.0]], "asks": [[1.01, 1.0]]}
+
+    monkeypatch.setattr(
+        fitness_mod,
+        "_build_adapter",
+        lambda _venue, _settings: DummyAdapter(),
+    )
+    monkeypatch.setattr(
+        fitness_mod,
+        "_triangles_for",
+        lambda _venue: [fitness_mod.Triangle("A/B", "B/C", "A/C")],
+    )
+    monkeypatch.setattr(fitness_mod, "_log_balances", lambda *_a, **_k: None)
+
+    def fake_try_triangle(_adapter, _tri, _books, _threshold, _reasons):
+        clock.value = 1.0
+        return {
+            "net_est": 0.123,
+            "realized_usdt": 2.5,
+            "fills": [{"qty": 0.01}],
+        }
+
+    monkeypatch.setattr(fitness_mod, "try_triangle", fake_try_triangle)
+
+    dummy_settings = SimpleNamespace(
+        dry_run=True,
+        sqlite_path=":memory:",
+        net_threshold_bps=0.0,
+        notional_per_trade_usd=0.0,
+        max_slippage_bps=0.0,
+        discord_min_notify_interval_secs=0.0,
+        discord_attempt_notify=False,
+    )
+    monkeypatch.setattr(fitness_mod, "settings", dummy_settings)
+
+    messages: list[str] = []
+
+    def fake_notify(_venue: str, message: str, **_kwargs) -> None:
+        messages.append(message)
+
+    monkeypatch.setattr(fitness_mod, "notify_discord", fake_notify)
+
+    caplog.set_level("INFO", logger="arbit")
+
+    fitness_mod.fitness(
+        venue="demo",
+        secs=1,
+        simulate=True,
+        persist=False,
+        attempt_notify=True,
+    )
+
+    assert any("attempt#1" in msg for msg in messages)
+    assert any("sim_trades_total=1" in msg for msg in messages)
+    assert any("attempt#1" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- add cumulative attempt counters to live CLI console logs and Discord payloads, including success totals
- mirror the attempt counter formatting in fitness simulations and expose sim trade totals in notifications
- add a regression test ensuring per-attempt Discord and CLI logs include the new counters

## Testing
- pytest -q *(fails: pyenv reports `pytest` command missing)*
- python -m pytest -q *(fails: pyenv cannot find Python 3.11.9 from .python-version)*
- python3 -m pytest -q *(fails: stdlib Python lacks pytest module)*

------
https://chatgpt.com/codex/tasks/task_e_68cac9363b688329b1406b6c07485514