### PR TITLE
Configure Caddy for DuckDNS domain

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,12 @@
+pynance-dietpi.duckdns.org {
+    encode zstd gzip
+
+    @api path /api/*
+    handle @api {
+        reverse_proxy {$BACKEND_UPSTREAM}
+    }
+
+    handle {
+        reverse_proxy {$FRONTEND_UPSTREAM}
+    }
+}


### PR DESCRIPTION
## Summary
- add a Caddyfile that proxies frontend and backend through pynance-dietpi.duckdns.org
- route /api requests to BACKEND_UPSTREAM and all other traffic to FRONTEND_UPSTREAM

## Testing
- pytest -q *(fails: pyenv reports Python 3.11.9 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad85ae89c8329aa772a87981dee41