### PR TITLE
fix: prevent --help-verbose TypeError

### DIFF
--- a/arbit/cli/core.py
+++ b/arbit/cli/core.py
@@ -99,7 +99,7 @@ class CLIApp(typer.Typer):
         """Print detailed command reference with optional command filtering."""
 
         typer.echo(VERBOSE_GLOBAL_OVERVIEW.strip())
-        typer.echo()
+        typer.echo("")
 
         if command:
             text = VERBOSE_COMMAND_HELP.get(command)
@@ -121,7 +121,7 @@ class CLIApp(typer.Typer):
             ]
             if aliases:
                 typer.echo(f"  Aliases: {', '.join(sorted(set(aliases)))}")
-            typer.echo()
+            typer.echo("")
 
     def print_verbose_help_for(self, command: str) -> None:
         """Expose verbose help rendering for command functions."""


### PR DESCRIPTION
## Summary
- replace bare typer.echo() calls in CLIApp verbose help with explicit blank strings
- avoid TypeError from Typer echo when using --help-verbose flags

## Testing
- pytest -q *(fails: pyenv: version `3.11.9` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cae3e7810483298d431002ed9b938b