### PR TITLE
feat: support multi-venue live flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ to drill into a single command's flags, sample output, and operational tips.
 
 - Global: `--help` (summary), `--help-verbose` (detailed catalog or command-specific when appended)
 - `fitness` flags: `--venue`, `--secs`, `--simulate/--no-simulate`, `--persist/--no-persist`, `--dummy-trigger`, `--help-verbose`
-- `live` flags: `--venue`, `--help-verbose`
-- `live:multi` flags: `--venues`, `--symbols`, `--auto-suggest-top`
-  - Example: `python -m arbit.cli live:multi --venues alpaca,kraken`
+- `live` flags: `--venue`, `--venues`, `--help-verbose`
+  - Example: `python -m arbit.cli live --venues alpaca,kraken`
   - Or use `./scripts/run_live_multi.sh` with `VENUES`, `SYMBOLS`, `AUTO_SUGGEST_TOP`
 - Helpers: `keys:check`, `markets:limits --venue --symbols`, `config:recommend --venue`
 - Yield: `yield:collect --asset USDC --reserve-usd 50` (beta, on-chain)

--- a/arbit/cli/__init__.py
+++ b/arbit/cli/__init__.py
@@ -38,7 +38,7 @@ from . import commands
 from .commands.config import config_discover, config_recommend
 from .commands.fitness import fitness, fitness_hybrid
 from .commands.keys import keys_check
-from .commands.live import live, live_multi
+from .commands.live import live
 from .commands.markets import markets_limits
 from .commands.notify import notify_test
 from .commands.yield_commands import yield_collect, yield_watch, yield_withdraw
@@ -92,7 +92,6 @@ __all__ = [
     "insert_yield_op",
     "keys_check",
     "live",
-    "live_multi",
     "log",
     "markets_limits",
     "notify_discord",

--- a/arbit/cli/commands/live.py
+++ b/arbit/cli/commands/live.py
@@ -40,9 +40,7 @@ def live(
         raise SystemExit(0)
 
     venue_list = [
-        v.strip()
-        for v in (venues.split(",") if venues else [venue])
-        if v.strip()
+        v.strip() for v in (venues.split(",") if venues else [venue]) if v.strip()
     ]
     if not venue_list:
         venue_list = [venue]

--- a/arbit/cli/commands/live.py
+++ b/arbit/cli/commands/live.py
@@ -16,6 +16,14 @@ from ..utils import _balances_brief, _build_adapter, _live_run_for_venue
 @app.command("live_run")
 def live(
     venue: str = "alpaca",
+    venues: str | None = TyperOption(
+        None,
+        "--venues",
+        help=(
+            "Comma-separated venues to trade concurrently. Overrides --venue when"
+            " provided."
+        ),
+    ),
     symbols: str | None = None,
     auto_suggest_top: int = 0,
     attempt_notify: bool | None = TyperOption(
@@ -25,80 +33,45 @@ def live(
     ),
     help_verbose: bool = False,
 ) -> None:
-    """Continuously scan for profitable triangles and execute trades."""
+    """Continuously scan for profitable triangles and execute trades across venues."""
 
     if help_verbose:
         app.print_verbose_help_for("live")
         raise SystemExit(0)
 
+    venue_list = [
+        v.strip()
+        for v in (venues.split(",") if venues else [venue])
+        if v.strip()
+    ]
+    if not venue_list:
+        venue_list = [venue]
+
     try:
         start_metrics_server(settings.prom_port)
     except Exception:
         pass
 
-    try:
-        asyncio.run(
-            _live_run_for_venue(
-                venue,
+    async def _run_for_all() -> None:
+        if len(venue_list) == 1:
+            await _live_run_for_venue(
+                venue_list[0],
                 symbols=symbols,
                 auto_suggest_top=auto_suggest_top,
                 attempt_notify_override=attempt_notify,
             )
-        )
-    except KeyboardInterrupt:
-        pass
-    finally:
-        if bool(getattr(settings, "discord_live_stop_notify", True)):
-            try:
-                adapter = _build_adapter(venue, settings)
-                notify_discord(
-                    venue, f"[live@{venue}] stop | {_balances_brief(adapter)}"
-                )
-            except Exception:
-                pass
+            return
 
-
-@app.command("live:multi")
-@app.command("live_multi")
-def live_multi(
-    venues: str | None = None,
-    symbols: str | None = None,
-    auto_suggest_top: int = 0,
-    attempt_notify: bool | None = TyperOption(
-        None,
-        "--attempt-notify/--no-attempt-notify",
-        help="Send per-attempt Discord alerts (noisy). Overrides env.",
-    ),
-    help_verbose: bool = False,
-) -> None:
-    """Run live trading loops concurrently across multiple venues."""
-
-    if help_verbose:
-        app.print_verbose_help_for("live:multi")
-        raise SystemExit(0)
-
-    venue_list = [
-        v.strip()
-        for v in (venues or ",".join(settings.exchanges)).split(",")
-        if v.strip()
-    ] or ["alpaca", "kraken"]
-
-    try:
-        start_metrics_server(settings.prom_port)
-    except Exception:
-        pass
-
-    async def _run_all() -> None:
         tasks = [
             asyncio.create_task(
                 _live_run_for_venue(
-                    v,
+                    venue_name,
                     symbols=symbols,
                     auto_suggest_top=auto_suggest_top,
                     attempt_notify_override=attempt_notify,
                 )
             )
-            for v in venue_list
+            for venue_name in venue_list
         ]
         try:
             await asyncio.gather(*tasks)
@@ -110,7 +83,7 @@ def live_multi(
                 task.cancel()
 
     try:
-        asyncio.run(_run_all())
+        asyncio.run(_run_for_all())
     except KeyboardInterrupt:
         pass
     finally:
@@ -126,4 +99,4 @@ def live_multi(
                     pass
 
 
-__all__ = ["live", "live_multi"]
+__all__ = ["live"]

--- a/arbit/cli/help_text.py
+++ b/arbit/cli/help_text.py
@@ -64,11 +64,13 @@ VERBOSE_COMMAND_HELP: dict[str, str] = {
             Continuously evaluate live triangles and place orders when the net spread beats
             configured thresholds. Intended for production once fitness results look healthy.
           Key flags:
+            --venues TEXT         CSV list of venues to trade concurrently.
             --venue TEXT           Venue to trade (default: alpaca).
             --symbols TEXT         CSV leg filter applied before triangle selection.
             --auto-suggest-top INT Auto-generate a shortlist of triangles when config is empty.
             --attempt-notify       Send Discord updates on every attempt (noisy, opt-in).
           Usage tips:
+            - ``--venues`` overrides ``--venue`` and spins up a loop per venue.
             - Confirm balances via the startup banner before trusting executions.
             - ``--symbols`` keeps exposure constrained to pairs you actively monitor.
             - ``--auto-suggest-top`` is useful for quick experiments; persists only for session.
@@ -76,25 +78,6 @@ VERBOSE_COMMAND_HELP: dict[str, str] = {
           Sample log lines:
             alpaca Triangle(ETH/USDT, ETH/BTC, BTC/USDT) net=0.42% PnL=0.11 USDT
             alpaca heartbeat: dry_run=True attempts=250 successes=3 hit_rate=1.20%
-        """
-    ),
-    "live:multi": dedent(
-        """\
-        live:multi
-          Purpose:
-            Orchestrate ``live`` loops for multiple venues concurrently in one process.
-            Shares metrics export and Discord notifications across venues.
-          Key flags:
-            --venues TEXT         CSV list of venues (default: settings.exchanges).
-            --symbols TEXT        CSV leg filter applied to every venue.
-            --auto-suggest-top INT Same as ``live`` but replicated per venue.
-            --attempt-notify       Forward ``--attempt-notify`` to every venue loop.
-          Usage tips:
-            - Provide ``--venues alpaca,kraken`` to reuse account configs side-by-side.
-            - Combine with different ``--symbols`` to avoid overlapping inventory drains.
-            - Graceful Ctrl+C waits for child tasks to cancel before shutting down metrics.
-          Sample usage:
-            python -m arbit.cli live:multi --venues alpaca,kraken --symbols ETH/USDT,ETH/BTC,BTC/USDT
         """
     ),
     "markets:limits": dedent(

--- a/scripts/run_live_multi.sh
+++ b/scripts/run_live_multi.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 VENUES=${VENUES:-"alpaca,kraken"}
-ARGS=(live:multi --venues "$VENUES")
+ARGS=(live --venues "$VENUES")
 
 if [[ -n "${SYMBOLS:-}" ]]; then
   ARGS+=(--symbols "$SYMBOLS")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ sys.modules["arbit.config"] = types.SimpleNamespace(
         net_threshold_bps=10.0,
         notional_per_trade_usd=200.0,
         exchanges=["alpaca"],
+        discord_live_stop_notify=False,
     )
 )
 
@@ -209,8 +210,6 @@ def test_help_lists_commands() -> None:
     assert result.exit_code == 0
     assert result.output.count("keys:check") == 1
     assert result.output.count("fitness") == 1
-    # The help output may list additional variants like ``live:multi``. Ensure
-    # the primary ``live`` command appears at least once.
     assert result.output.count("live") >= 1
     assert result.output.count("markets:limits") == 1
     assert result.output.count("config:recommend") == 1
@@ -234,12 +233,46 @@ def test_command_help_verbose_filters_sections() -> None:
     result = runner.invoke(cli.app, ["fitness", "--help-verbose"])
     assert result.exit_code == 0
     assert "Monitor bid/ask spreads" in result.output
-    assert "live:multi" not in result.output
+    assert "--venues" not in result.output
 
-    alias_result = runner.invoke(cli.app, ["live_multi", "--help-verbose"])
-    assert alias_result.exit_code == 0
-    assert "live:multi" in alias_result.output
-    assert "markets:limits" not in alias_result.output
+    live_result = runner.invoke(cli.app, ["live", "--help-verbose"])
+    assert live_result.exit_code == 0
+    assert "--venues" in live_result.output
+    assert "markets:limits" not in live_result.output
+
+
+def test_live_command_accepts_single_venue(monkeypatch) -> None:
+    """`live` should run a single venue loop when only `--venue` is provided."""
+
+    calls: list[str] = []
+
+    async def _fake_live(venue: str, **_: object) -> None:
+        calls.append(venue)
+
+    monkeypatch.setattr(cli, "_live_run_for_venue", _fake_live)
+    monkeypatch.setattr(cli, "start_metrics_server", lambda *_a, **_k: None)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["live", "--venue", "alpaca"])
+    assert result.exit_code == 0
+    assert calls == ["alpaca"]
+
+
+def test_live_command_runs_multiple_venues(monkeypatch) -> None:
+    """`live --venues` should fan out concurrent loops for each venue supplied."""
+
+    calls: list[str] = []
+
+    async def _fake_live(venue: str, **_: object) -> None:
+        calls.append(venue)
+
+    monkeypatch.setattr(cli, "_live_run_for_venue", _fake_live)
+    monkeypatch.setattr(cli, "start_metrics_server", lambda *_a, **_k: None)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["live", "--venues", "alpaca,kraken"])
+    assert result.exit_code == 0
+    assert set(calls) == {"alpaca", "kraken"}
 
 
 def test_markets_limits(monkeypatch):


### PR DESCRIPTION
## Summary
- extend the `live` command to accept a `--venues` CSV and fan out concurrent loops internally
- document the new flag in verbose help, README guidance, and the helper script
- refresh CLI tests to cover single- and multi-venue flows and updated help output

## Testing
- `python -m pytest tests/test_cli.py -q` *(fails: pytest not installed in sandbox and network access is restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68ccda83fe4483298c677443c282d926