### PR TITLE
feat: support multi-venue live flag

### DIFF
--- a/arbit/cli/help_text.py
+++ b/arbit/cli/help_text.py
@@ -64,8 +64,8 @@ VERBOSE_COMMAND_HELP: dict[str, str] = {
             Continuously evaluate live triangles and place orders when the net spread beats
             configured thresholds. Intended for production once fitness results look healthy.
           Key flags:
-            --venues TEXT         CSV list of venues to trade concurrently.
-            --venue TEXT           Venue to trade (default: alpaca).
+            --venues TEXT         CSV list of venues to trade concurrently (overrides --venue).
+            --venue TEXT           Single venue fallback when --venues is omitted (default: alpaca).
             --symbols TEXT         CSV leg filter applied before triangle selection.
             --auto-suggest-top INT Auto-generate a shortlist of triangles when config is empty.
             --attempt-notify       Send Discord updates on every attempt (noisy, opt-in).


### PR DESCRIPTION
## Summary
- update the `live` command to accept a comma-separated `--venues` flag and deduplicate venue entries before spawning per-venue tasks
- refresh the verbose help text to document the `--venues` override of `--venue`
- extend CLI tests to cover both the single-venue path and the new multi-venue fan-out and to verify help output

## Testing
- python -m pytest --cov *(fails: pytest not available; pip install blocked by proxy)*
- pip install -r requirements.txt pytest *(fails: proxy 403 prevents dependency download)*
- pip install ruff *(fails: proxy 403 prevents dependency download)*

------
https://chatgpt.com/codex/tasks/task_e_68cd057f6af08329afa55861ce6a5718