### PR TITLE
feat: configure Alpaca data feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ export ALPACA_API_KEY=your_alpaca_key
 export ALPACA_API_SECRET=your_alpaca_secret
 export ALPACA_BASE_URL=https://paper-api.alpaca.markets  # Paper trading
 export ALPACA_WS_CRYPTO_URL=wss://stream.data.alpaca.markets/v1beta3/crypto/us  # optional
+export ALPACA_DATA_FEED=us  # optional: set "sip" for the paid low-latency feed
 export ALPACA_MAP_USDT_TO_USD=true  # treat /USDT pairs as /USD
 
 # Kraken
@@ -243,6 +244,11 @@ export DISCORD_TRADE_NOTIFY=false                                  # trade-only 
 export DISCORD_ATTEMPT_NOTIFY=false                                # per-attempt alerts (noisy)
 export DISCORD_MIN_NOTIFY_INTERVAL_SECS=10                         # rate limit seconds
 ```
+
+Set ``ALPACA_DATA_FEED=sip`` together with the corresponding SIP websocket
+endpoint (``wss://stream.data.alpaca.markets/v1beta3/crypto/sip``) to use the
+low-latency data feed when your account is entitled to it; the defaults point to
+the standard retail ``us`` feed.
 
 ### Using .env Files
 

--- a/arbit/adapters/alpaca_adapter.py
+++ b/arbit/adapters/alpaca_adapter.py
@@ -187,7 +187,12 @@ class AlpacaAdapter(ExchangeAdapter):
             await queue.put((out_sym, {"bids": bids, "asks": asks}))
 
         while True:
-            stream = CryptoDataStream(self._key, self._secret)
+            stream = CryptoDataStream(
+                self._key,
+                self._secret,
+                url=getattr(settings, "alpaca_ws_crypto_url", None),
+                data_feed=getattr(settings, "alpaca_data_feed", None),
+            )
             self._stream = stream
             stream.subscribe_orderbooks(_handler, *sub_syms)
             run_task = asyncio.create_task(stream._run_forever())  # type: ignore[attr-defined]

--- a/arbit/config.py
+++ b/arbit/config.py
@@ -170,6 +170,8 @@ class Settings(BaseSettings):
     alpaca_base_url: str = "https://api.alpaca.markets"
     # Websocket endpoint for crypto order book streams.
     alpaca_ws_crypto_url: str = "wss://stream.data.alpaca.markets/v1beta3/crypto/us"
+    # Streaming data feed selection (``us`` retail by default, ``sip`` for paid).
+    alpaca_data_feed: str = "us"
 
     kraken_api_key: str | None = None
     kraken_api_secret: str | None = None
@@ -321,6 +323,17 @@ class Settings(BaseSettings):
             "alpaca_map_usdt_to_usd",
         ):
             _coerce_bool(b)
+
+        def _coerce_lower(attr: str, default: str | None = None) -> None:
+            v = getattr(self, attr, None)
+            if v is None:
+                return
+            cleaned = str(v).strip()
+            if not cleaned and default is None:
+                return
+            setattr(self, attr, (cleaned or default or "").lower())
+
+        _coerce_lower("alpaca_data_feed", default="us")
 
         if isinstance(self.exchanges, str):
             try:

--- a/docs/WARP.md
+++ b/docs/WARP.md
@@ -62,6 +62,7 @@ net   = gross * (1 - fee)^3 - 1
 **Alpaca Settings:**
 - `ALPACA_BASE_URL` to select paper or live API endpoint
 - `ALPACA_WS_CRYPTO_URL` to override websocket endpoint
+- `ALPACA_DATA_FEED` to choose between retail ``us`` and paid ``sip`` streams
 - `ALPACA_MAP_USDT_TO_USD` to treat `/USDT` symbols as `/USD`
 
 **Models:**
@@ -182,7 +183,11 @@ net   = gross * (1 - fee)^3 - 1
 ### Alpaca Settings
 - `ALPACA_BASE_URL` controls paper vs live REST endpoint
 - `ALPACA_WS_CRYPTO_URL` overrides websocket stream
+- `ALPACA_DATA_FEED` selects `us` (default retail) vs `sip` (paid low-latency)
 - Enable `ALPACA_MAP_USDT_TO_USD` to map `/USDT` pairs to `/USD`
+- Pair `ALPACA_DATA_FEED=sip` with the SIP websocket URL
+  (`wss://stream.data.alpaca.markets/v1beta3/crypto/sip`) when entitled to the
+  faster feed; otherwise keep the defaults for the standard retail stream.
 
 ### CCXT Errors (Kraken)
 - Keep `enableRateLimit=True`; reduce polling frequency if rate-limited

--- a/tests/alpaca_mocks.py
+++ b/tests/alpaca_mocks.py
@@ -52,9 +52,19 @@ class MockDataStream:
     updates_runs: List[List[Any]] = []
     run_index = 0
 
-    def __init__(self, key: str, secret: str) -> None:
+    def __init__(
+        self,
+        key: str,
+        secret: str,
+        *,
+        url: str | None = None,
+        data_feed: str | None = None,
+        **_: Any,
+    ) -> None:
         self.handler = None
         self.symbols: tuple[str, ...] = ()
+        self.url = url
+        self.data_feed = data_feed
         self.idx = MockDataStream.run_index
         MockDataStream.run_index += 1
         MockDataStream.instances.append(self)


### PR DESCRIPTION
## Summary
- add an `alpaca_data_feed` setting that normalises env input and defaults to the retail `us` stream
- pass both the configured websocket URL and feed into the Alpaca crypto data stream and update streaming tests
- document the new `ALPACA_DATA_FEED` environment variable alongside websocket overrides

## Testing
- .venv/bin/python -m pytest tests/test_streaming.py *(fails: No module named pytest; dependency installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cdadeae0a083298f0aa581327afd7e