### PR TITLE
Persist skip attempt metadata in live loop

### DIFF
--- a/arbit/cli/utils.py
+++ b/arbit/cli/utils.py
@@ -355,7 +355,9 @@ async def _live_run_for_venue(
 
                 skip_reason_str = ",".join(reason_list)
 
-                def _price(snapshot: dict[str, float | None | str] | None, key: str) -> float | None:
+                def _price(
+                    snapshot: dict[str, float | None | str] | None, key: str
+                ) -> float | None:
                     if not isinstance(snapshot, dict):
                         return None
                     value = snapshot.get(key)
@@ -386,7 +388,9 @@ async def _live_run_for_venue(
                                 getattr(settings, "max_slippage_bps", 0.0) or 0.0
                             ),
                             dry_run=bool(getattr(settings, "dry_run", True)),
-                            latency_ms=(float(latency) * 1000.0 if latency is not None else None),
+                            latency_ms=(
+                                float(latency) * 1000.0 if latency is not None else None
+                            ),
                             skip_reasons=skip_reason_str,
                             ab_bid=_price(tob_snapshot.get(tri.leg_ab), "bid"),
                             ab_ask=_price(tob_snapshot.get(tri.leg_ab), "ask"),

--- a/tests/test_cli_live_attempts.py
+++ b/tests/test_cli_live_attempts.py
@@ -57,7 +57,9 @@ async def test_live_run_records_skip_attempt(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli_utils, "settings", dummy_settings)
     monkeypatch.setattr(cli_utils, "_triangles_for", lambda _venue: [triangle])
-    monkeypatch.setattr(cli_utils, "_build_adapter", lambda _venue, _settings: DummyAdapter())
+    monkeypatch.setattr(
+        cli_utils, "_build_adapter", lambda _venue, _settings: DummyAdapter()
+    )
     monkeypatch.setattr(cli_utils, "_log_balances", lambda *_a, **_k: None)
     monkeypatch.setattr(cli_utils, "notify_discord", lambda *_a, **_k: None)
 


### PR DESCRIPTION
## Summary
- persist skipped triangle attempts from `_live_run_for_venue` with joined reasons and top-of-book snapshots
- adjust skip notifications to reuse the aggregated reason string
- add a regression test covering skip attempt persistence

## Testing
- PYENV_VERSION=3.11.12 python -m pytest *(fails: missing ccxt and prometheus_client dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaee703f08329872220c9fba0ea55