### PR TITLE
fix: respect explicit empty triangle lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ asyncio.run(main())
 
 **Supported Venues**: `alpaca`, `kraken`
 
-**Note**: Ensure triangle symbols exist on your chosen venue (e.g., ETH/USDT, ETH/BTC, BTC/USDT; SOL/USDT, SOL/BTC, BTC/USDT on supported venues like Kraken). See [WARP.md CLI Commands](docs/WARP.md#cli-commands) for full documentation.
+**Note**: Ensure triangle symbols exist on your chosen venue (e.g., ETH/USDT, ETH/BTC, BTC/USDT; SOL/USDT, SOL/BTC, BTC/USDT on supported venues like Kraken). See [WARP.md CLI Commands](docs/WARP.md#cli-commands) for full documentation. Alpaca's configuration intentionally ships with no default triangles to avoid unsupported crypto-to-crypto crosses, so set `TRIANGLES_BY_VENUE` (or pass `--symbols`) when you're ready to trade there.
 
 Customizing triangles (advanced): set `TRIANGLES_BY_VENUE` as JSON in `.env` to override defaults, e.g.
 ```

--- a/arbit/cli/utils.py
+++ b/arbit/cli/utils.py
@@ -56,7 +56,11 @@ def format_live_heartbeat(
 
 
 def _triangles_for(venue: str) -> list[Triangle]:
-    """Return configured triangles for *venue*, falling back to defaults."""
+    """Return configured triangles for *venue*, falling back to defaults.
+
+    Explicit empty lists (e.g., Alpaca's default configuration) are respected so
+    operators can opt-in with venue-specific triangles when ready.
+    """
 
     data_raw = getattr(settings, "triangles_by_venue", {}) or {}
     data = data_raw
@@ -79,7 +83,7 @@ def _triangles_for(venue: str) -> list[Triangle]:
         data = {}
 
     triples = data.get(venue)
-    if not isinstance(triples, list) or not triples:
+    if not isinstance(triples, list):
         triples = [
             ["ETH/USDT", "ETH/BTC", "BTC/USDT"],
             ["ETH/USDC", "ETH/BTC", "BTC/USDC"],

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,0 +1,36 @@
+"""Tests for CLI utility helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from arbit.cli import utils as cli_utils
+from arbit.models import Triangle
+
+
+def test_triangles_for_respects_explicit_empty_list(monkeypatch) -> None:
+    """An explicit empty list should disable fallback defaults."""
+
+    monkeypatch.setattr(
+        cli_utils,
+        "settings",
+        SimpleNamespace(triangles_by_venue={"alpaca": []}),
+    )
+
+    assert cli_utils._triangles_for("alpaca") == []
+
+
+def test_triangles_for_missing_venue_uses_fallback(monkeypatch) -> None:
+    """Missing venue definitions should still return the default templates."""
+
+    monkeypatch.setattr(
+        cli_utils,
+        "settings",
+        SimpleNamespace(triangles_by_venue={}),
+    )
+
+    triangles = cli_utils._triangles_for("kraken")
+
+    assert triangles  # default fallback templates
+    assert all(isinstance(tri, Triangle) for tri in triangles)
+    assert triangles[0].leg_ab == "ETH/USDT"


### PR DESCRIPTION
## Summary
- ensure `_triangles_for` preserves explicitly empty triangle configurations instead of applying the ETH/BTC fallback
- add tests covering the Alpaca empty-list case and fallback default behavior
- document that Alpaca ships without default triangles so operators must configure their own

## Testing
- `PYENV_VERSION=3.11.12 pyenv exec ruff check tests/test_cli_utils.py`
- `PYENV_VERSION=3.11.12 pyenv exec black tests/test_cli_utils.py`
- `PYENV_VERSION=3.11.12 pyenv exec pytest tests/test_cli_utils.py -q` *(fails: missing prometheus_client dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce747a599c832998d0ee4418ce2f8f