### PR TITLE
fix: remove unused import in fitness CLI

### DIFF
--- a/arbit/cli/commands/fitness.py
+++ b/arbit/cli/commands/fitness.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from arbit.adapters import ExchangeAdapter
 from arbit.config import settings
-from arbit.models import Fill, Triangle, TriangleAttempt
+from arbit.models import Fill, TriangleAttempt
 from arbit.notify import notify_discord
 from arbit.persistence.db import init_db, insert_attempt, insert_fill, insert_triangle
 


### PR DESCRIPTION
## Summary
- remove the unused Triangle import from the fitness command module to satisfy linters

## Testing
- pytest -q *(fails: pyenv missing configured Python version)*
- PYENV_VERSION=3.11.12 python -m pytest -q *(fails: missing prometheus_client dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa46e53948329ade1cc957dfeb996