### PR TITLE
Fix staking helpers to respect dry-run safety

### DIFF
--- a/tests/test_stake.py
+++ b/tests/test_stake.py
@@ -111,7 +111,9 @@ class DummyAccount:
     address = "0xacct"
 
     def sign_transaction(self, tx: dict) -> types.SimpleNamespace:
-        return types.SimpleNamespace(rawTransaction=f"signed-{tx['nonce']}-{tx['kind']}")
+        return types.SimpleNamespace(
+            rawTransaction=f"signed-{tx['nonce']}-{tx['kind']}"
+        )
 
 
 def test_stake_usdc_dry_run_skips_web3(monkeypatch, caplog):

--- a/tests/test_stake.py
+++ b/tests/test_stake.py
@@ -1,69 +1,199 @@
-"""Tests for staking helper functions."""
+"""Tests for the Aave staking helper module."""
 
-import pytest
+from __future__ import annotations
 
-from stake import ensure_account_ready
+import logging
+import types
+
+import stake
 
 
-class DummyCall:
-    def __init__(self, value: int) -> None:
-        self._value = value
+def patch_settings(monkeypatch, *, dry_run: bool) -> None:
+    """Override :func:`stake._load_settings` with a deterministic stub."""
 
-    def call(self) -> int:  # pragma: no cover - trivial
-        return self._value
+    monkeypatch.setattr(stake, "_load_settings", lambda: DummySettings(dry_run=dry_run))
+
+
+class DummySettings:
+    """Minimal settings stub for staking tests."""
+
+    def __init__(self, *, dry_run: bool):
+        self.dry_run = dry_run
+        self.usdc_address = "0xusdc"
+        self.pool_address = "0xpool"
+        self.min_usdc_stake = 1
+        self.min_eth_balance_wei = 1
+        self.max_gas_price_gwei = 5
+
+
+class DummyTokenFunctions:
+    """Emulate ERC20 contract functions used by :mod:`stake`."""
+
+    def __init__(self, token: "DummyToken") -> None:
+        self._token = token
+
+    def balanceOf(self, _owner: str):  # noqa: N802 - mimic Web3 naming
+        return types.SimpleNamespace(call=lambda: self._token.balance)
+
+    def approve(self, spender: str, value: int):  # noqa: N802
+        self._token.approve_args.append((spender, value))
+        return types.SimpleNamespace(
+            build_transaction=lambda params: {**params, "kind": "approve"}
+        )
 
 
 class DummyToken:
-    def __init__(self, balance: int) -> None:
-        self._balance = balance
-        self.functions = self
+    """ERC20 token stub capturing approve calls."""
 
-    def balanceOf(self, _addr: str) -> DummyCall:  # pragma: no cover - simple
-        return DummyCall(self._balance)
+    def __init__(self, balance: int) -> None:
+        self.address = "0xusdc"
+        self.balance = balance
+        self.approve_args: list[tuple[str, int]] = []
+        self.functions = DummyTokenFunctions(self)
+
+
+class DummyPoolFunctions:
+    """Simulate the subset of pool contract methods we invoke."""
+
+    def __init__(self, pool: "DummyPool") -> None:
+        self._pool = pool
+
+    def supply(self, asset: str, amount: int, on_behalf: str, referral: int):  # noqa: N802
+        self._pool.supply_args.append((asset, amount, on_behalf, referral))
+        return types.SimpleNamespace(
+            build_transaction=lambda params: {**params, "kind": "supply"}
+        )
+
+    def withdraw(self, asset: str, amount: int, to: str):  # noqa: N802
+        self._pool.withdraw_args.append((asset, amount, to))
+        return types.SimpleNamespace(
+            build_transaction=lambda params: {**params, "kind": "withdraw"}
+        )
+
+
+class DummyPool:
+    """Aave pool contract stub tracking supply/withdraw invocations."""
+
+    def __init__(self) -> None:
+        self.address = "0xpool"
+        self.supply_args: list[tuple[str, int, str, int]] = []
+        self.withdraw_args: list[tuple[str, int, str]] = []
+        self.functions = DummyPoolFunctions(self)
 
 
 class DummyEth:
-    def __init__(self, balance: int) -> None:
-        self._balance = balance
+    """Minimal Web3 ``eth`` namespace used in staking routines."""
 
-    def get_balance(self, _addr: str) -> int:  # pragma: no cover - trivial
-        return self._balance
+    def __init__(self, sent: list[str]) -> None:
+        self._sent = sent
+        self.gas_price = 2 * 10**9
+
+    def get_balance(self, _address: str) -> int:  # pragma: no cover - trivial
+        return 10**18
+
+    def get_transaction_count(self, _address: str) -> int:
+        return len(self._sent)
+
+    def send_raw_transaction(self, raw: str) -> None:
+        self._sent.append(raw)
 
 
-class DummyW3:
-    def __init__(self, balance: int) -> None:
-        self.eth = DummyEth(balance)
+class DummyWeb3:
+    """Container providing the ``eth`` namespace for staking tests."""
+
+    def __init__(self, sent: list[str]) -> None:
+        self.eth = DummyEth(sent)
 
 
 class DummyAccount:
-    def __init__(self, address: str) -> None:
-        self.address = address
+    """Account stub returning deterministic signatures."""
+
+    address = "0xacct"
+
+    def sign_transaction(self, tx: dict) -> types.SimpleNamespace:
+        return types.SimpleNamespace(rawTransaction=f"signed-{tx['nonce']}-{tx['kind']}")
 
 
-def test_account_ready() -> None:
-    """No error when balances meet the requirements."""
+def test_stake_usdc_dry_run_skips_web3(monkeypatch, caplog):
+    """Dry-run mode should avoid initialising Web3 clients."""
 
-    w3 = DummyW3(balance=10**18)
-    token = DummyToken(balance=1_000)
-    acct = DummyAccount("0xabc")
-    ensure_account_ready(w3, acct, token, amount=100, min_token=100, min_eth=10**17)
+    patch_settings(monkeypatch, dry_run=True)
+
+    called = False
+
+    def fake_init(settings):  # pragma: no cover - executed when test fails
+        nonlocal called
+        called = True
+        return stake._init_web3_clients(settings)
+
+    monkeypatch.setattr(stake, "_init_web3_clients", fake_init)
+
+    with caplog.at_level(logging.INFO):
+        stake.stake_usdc(1_500_000)
+
+    assert called is False
+    assert "[dry-run]" in caplog.text
 
 
-def test_insufficient_token_raises() -> None:
-    """A low USDC balance raises a ``ValueError``."""
+def test_stake_usdc_live_executes_transactions(monkeypatch):
+    """Live staking should submit approve and supply transactions."""
 
-    w3 = DummyW3(balance=10**18)
-    token = DummyToken(balance=50)
-    acct = DummyAccount("0xabc")
-    with pytest.raises(ValueError):
-        ensure_account_ready(w3, acct, token, amount=100, min_token=100, min_eth=10**17)
+    patch_settings(monkeypatch, dry_run=False)
+
+    sent: list[str] = []
+    token = DummyToken(balance=2_000_000)
+    pool = DummyPool()
+    account = DummyAccount()
+
+    def fake_init(_settings):
+        return DummyWeb3(sent), account, token, pool
+
+    monkeypatch.setattr(stake, "_init_web3_clients", fake_init)
+
+    stake.stake_usdc(1_000_000)
+
+    assert sent == ["signed-0-approve", "signed-1-supply"]
+    assert token.approve_args == [(pool.address, 1_000_000)]
+    assert pool.supply_args == [(token.address, 1_000_000, account.address, 0)]
 
 
-def test_insufficient_eth_raises() -> None:
-    """A low ETH balance raises a ``ValueError``."""
+def test_withdraw_usdc_respects_dry_run(monkeypatch, caplog):
+    """Dry-run withdraw should bypass Web3 initialisation."""
 
-    w3 = DummyW3(balance=10**16)
-    token = DummyToken(balance=1_000)
-    acct = DummyAccount("0xabc")
-    with pytest.raises(ValueError):
-        ensure_account_ready(w3, acct, token, amount=100, min_token=100, min_eth=10**17)
+    patch_settings(monkeypatch, dry_run=True)
+
+    invoked = False
+
+    def fake_init(settings):  # pragma: no cover - executed when dry-run fails
+        nonlocal invoked
+        invoked = True
+        return stake._init_web3_clients(settings)
+
+    monkeypatch.setattr(stake, "_init_web3_clients", fake_init)
+
+    with caplog.at_level(logging.INFO):
+        stake.withdraw_usdc(500_000)
+
+    assert invoked is False
+    assert "[dry-run]" in caplog.text
+
+
+def test_withdraw_usdc_live_executes_transaction(monkeypatch):
+    """Live withdraw should submit a single transaction."""
+
+    patch_settings(monkeypatch, dry_run=False)
+
+    sent: list[str] = []
+    token = DummyToken(balance=2_000_000)
+    pool = DummyPool()
+    account = DummyAccount()
+
+    def fake_init(_settings):
+        return DummyWeb3(sent), account, token, pool
+
+    monkeypatch.setattr(stake, "_init_web3_clients", fake_init)
+
+    stake.withdraw_usdc(750_000)
+
+    assert sent == ["signed-0-withdraw"]
+    assert pool.withdraw_args == [(token.address, 750_000, account.address)]


### PR DESCRIPTION
## Summary
- guard the `stake_usdc` and `withdraw_usdc` routines so they honour Settings.dry_run
- factor out Web3/client initialisation and settings loading helpers for easier testing
- add comprehensive stake helper tests covering dry-run and live execution paths

## Testing
- python -m pytest tests/test_stake.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d05b7994f08329a7814c68eebed3e9