### PR TITLE
Fix websocket fallback handling in CCXTAdapter

### DIFF
--- a/arbit/adapters/ccxt_adapter.py
+++ b/arbit/adapters/ccxt_adapter.py
@@ -256,7 +256,6 @@ class CCXTAdapter(ExchangeAdapter):
                                 logger.error(
                                     "ws watch_order_book setup failed %s: %s", sym, exc
                                 )
-                                raise
 
                     if not tasks_by_sym:
                         break
@@ -316,7 +315,6 @@ class CCXTAdapter(ExchangeAdapter):
                                     sym,
                                     exc,
                                 )
-                                raise
 
                         yield sym, ob
 


### PR DESCRIPTION
## Summary
- stop re-raising websocket setup and restart exceptions in CCXTAdapter.orderbook_stream
- allow the adapter to fall back to REST polling when ccxt.pro order book tasks fail

## Testing
- pytest -q *(fails: pyenv missing interpreter 3.11.9)*

------
https://chatgpt.com/codex/tasks/task_e_68d065cc7d6c8329a0b685b09811e5d9