### PR TITLE
docs: update roadmap websocket progress

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -139,15 +139,15 @@ net   = gross * (1 - fee)^3 - 1
 ### Phase 2 (Production Ready)
  - [ ] WebSocket order books for reduced latency
    - [x] CLI scaffolding and adapter method (`orderbook_stream`)
-   - [ ] Initialize `ccxt.pro` client when available (`ex_ws`)
-   - [ ] Fallback to REST with staleness guard and metrics
-   - [ ] Basic tests with mocked stream/polling
+   - [x] Initialize `ccxt.pro` client when available (`ex_ws`)
+   - [x] Fallback to REST with staleness guard and metrics
+   - [x] Basic tests with mocked stream/polling
  - [x] Multi-venue live mode (concurrent)
    - [x] `live:multi` command with per-venue loops
    - [x] Discord notifications include balances per venue
  - [ ] Multi-symbol rotation and inventory rebalancing
  - [ ] Prometheus metrics and monitoring
-   - [ ] Order book staleness histogram
+   - [x] Order book staleness histogram
    - [ ] Error counters for WS connect/retry
 
 See `ROADMAP_PHASE_II.md` for detailed Phase II deliverables, acceptance criteria, and test plan.

--- a/docs/ROADMAP_PHASE_II.md
+++ b/docs/ROADMAP_PHASE_II.md
@@ -29,9 +29,13 @@ This document expands Phase II into concrete, testable deliverables needed to ru
 
 Progress
 - [x] Stream API surface in adapter (`orderbook_stream`) with REST fallback.
-- [ ] Initialize `ccxt.pro` client (`ex_ws`) when present; per-symbol watch with retries.
-- [ ] Add `orderbook_staleness_seconds` histogram; measure inter-update deltas.
-- [ ] Tests with fake stream to validate staleness and fallback behavior.
+- [x] Initialize `ccxt.pro` client (`ex_ws`) when present; per-symbol watch with retries.
+- [x] Add `orderbook_staleness_seconds` histogram; measure inter-update deltas.
+- [x] Tests with fake stream to validate staleness and fallback behavior.
+
+Automated coverage:
+- `tests/test_ccxt_adapter_stream.py` validates per-symbol websocket tasks and graceful closure.
+- `tests/test_streaming.py` exercises websocket failures, REST fallback, and staleness metric emissions.
 
 ### 2) Execution Engine Hardening
 - Place IOC limit orders for all legs; enforce per-leg `max_slippage_bps` and `min_notional`.


### PR DESCRIPTION
## Summary
- mark the websocket integration subtasks in `docs/ROADMAP.md` as delivered now that the adapter initialises `ccxt.pro`, falls back to REST with metrics, and carries dedicated tests
- reflect the same progress in `docs/ROADMAP_PHASE_II.md` and document the automated test coverage that exercises the streaming code path
- note that the Prometheus staleness histogram is already shipping

## Testing
- python3 -m pytest tests/test_ccxt_adapter_stream.py tests/test_streaming.py -q *(fails: pytest missing and `pip install pytest` blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d15c7a65648329b309db052c794807