### PR TITLE
Seed Alpaca defaults with SOL/BTC/USD triangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,12 +347,12 @@ asyncio.run(main())
 
 **Supported Venues**: `alpaca`, `kraken`
 
-**Note**: Ensure triangle symbols exist on your chosen venue (e.g., ETH/USDT, ETH/BTC, BTC/USDT; SOL/USDT, SOL/BTC, BTC/USDT on supported venues like Kraken). See [WARP.md CLI Commands](docs/WARP.md#cli-commands) for full documentation. Alpaca's configuration intentionally ships with no default triangles to avoid unsupported crypto-to-crypto crosses. Arbit will not fall back to ETH/BTC templates for Alpaca, so set `TRIANGLES_BY_VENUE` (or pass `--symbols`) once you're ready to trade there.
+**Note**: Ensure triangle symbols exist on your chosen venue (e.g., ETH/USDT, ETH/BTC, BTC/USDT; SOL/USDT, SOL/BTC, BTC/USDT on supported venues like Kraken). See [WARP.md CLI Commands](docs/WARP.md#cli-commands) for full documentation. Alpaca now includes a default SOL/USD → SOL/BTC → BTC/USD template, but verify the legs with `keys:check` before live trading. Override the defaults (or pass `--symbols`) if your venue lists alternate liquidity pairs.
 
 Customizing triangles (advanced): set `TRIANGLES_BY_VENUE` as JSON in `.env` to override defaults, e.g.
 ```
 TRIANGLES_BY_VENUE={
-  "alpaca": [["ETH/USDT","ETH/BTC","BTC/USDT"],["SOL/USDT","SOL/BTC","BTC/USDT"]],
+  "alpaca": [["SOL/USD","SOL/BTC","BTC/USD"]],
   "kraken": [["ETH/USDC","ETH/BTC","BTC/USDC"]]
 }
 ```

--- a/arbit/config.py
+++ b/arbit/config.py
@@ -14,7 +14,9 @@ from typing import Annotated, Any, List
 validator = None
 field_validator = None
 try:  # Prefer Pydantic v2 validator helper when available
-    from pydantic import field_validator as _pydantic_field_validator  # type: ignore[attr-defined]
+    from pydantic import (
+        field_validator as _pydantic_field_validator,  # type: ignore[attr-defined]
+    )
 except Exception:  # pragma: no cover - dependency optional across versions
     _pydantic_field_validator = None
 else:  # pragma: no cover - decorator only used when available
@@ -22,7 +24,9 @@ else:  # pragma: no cover - decorator only used when available
 
 if field_validator is None:  # Fallback to Pydantic v1 validator helper
     try:
-        from pydantic import validator as _pydantic_validator  # type: ignore[attr-defined]
+        from pydantic import (
+            validator as _pydantic_validator,  # type: ignore[attr-defined]
+        )
     except Exception:  # pragma: no cover - dependency optional across versions
         _pydantic_validator = None
     else:  # pragma: no cover - decorator only used when available

--- a/arbit/config.py
+++ b/arbit/config.py
@@ -264,9 +264,9 @@ class Settings(BaseSettings):
     # Per-venue triangle definitions (override via JSON in env if desired)
     # Format: { venue: [[leg_ab, leg_bc, leg_ac], ...], ... }
     triangles_by_venue: dict[str, list[list[str]]] = {
-        # Alpaca crypto typically lacks crypto-to-crypto crosses like ETH/BTC.
-        # Leave empty by default to avoid unsupported-symbol errors.
-        "alpaca": [],
+        # Alpaca recently listed SOL/BTC alongside USD legs, unlocking a default
+        # triangle that avoids manual configuration for paper trading.
+        "alpaca": [["SOL/USD", "SOL/BTC", "BTC/USD"]],
         "kraken": [
             ["ETH/USDT", "ETH/BTC", "BTC/USDT"],
             ["ETH/USDC", "ETH/BTC", "BTC/USDC"],

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -55,12 +55,17 @@ def test_triangles_for_respects_explicit_empty_list(monkeypatch) -> None:
     assert cli_utils._triangles_for("alpaca") == []
 
 
-def test_triangles_for_default_settings_leave_alpaca_empty() -> None:
-    """Default configuration keeps Alpaca triangles empty until configured."""
+def test_triangles_for_default_settings_include_alpaca_sol_triangle() -> None:
+    """Default configuration seeds Alpaca with the SOL/BTC/USD triangle."""
 
     triangles = cli_utils._triangles_for("alpaca")
 
-    assert triangles == []
+    assert triangles
+    assert (triangles[0].leg_ab, triangles[0].leg_bc, triangles[0].leg_ac) == (
+        "SOL/USD",
+        "SOL/BTC",
+        "BTC/USD",
+    )
 
 
 def test_triangles_for_missing_venue_uses_fallback(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add the SOL/USD → SOL/BTC → BTC/USD triangle to the default Alpaca configuration
- update README guidance and CLI utility expectations for the seeded triangle

## Testing
- pytest -q *(fails: pyenv missing Python 3.11.9 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d2065ee88329a386ca2767e91532