### PR TITLE
Add Kraken ZIG promo workflow to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ Key safeguards:
 - Sells the asset back to the quote currency by default to keep exposure flat (use `--hold` to keep it).
 - Requires both `--execute` **and** `DRY_RUN=false` to place real orders.
 
+Need an automated helper for Kraken's ZIG promotions? The main CLI now ships a `promo`
+command that accumulates ZIG up to a target balance and, when executed, waits until the
+configured UTC timestamp to unwind the position automatically:
+
+```bash
+# Preview the workflow (no orders placed)
+python -m arbit.cli promo --check-interval 60
+
+# Execute the workflow once you're ready
+export DRY_RUN=false
+python -m arbit.cli promo --execute --sell-at 2024-10-06T00:01:00+00:00
+```
+
+The command keeps running until the scheduled liquidation time so that the sell leg can
+fire automatically once the promotion window opens.
+
 ## Installation
 
 **Requirements:** Python 3.10+ recommended

--- a/arbit/cli/__init__.py
+++ b/arbit/cli/__init__.py
@@ -41,6 +41,7 @@ from .commands.keys import keys_check
 from .commands.live import live
 from .commands.markets import markets_limits
 from .commands.notify import notify_test
+from .commands.promo import promo
 from .commands.yield_commands import yield_collect, yield_watch, yield_withdraw
 from .core import CLIApp, TyperOption, app, log
 from .help_text import VERBOSE_COMMAND_HELP, VERBOSE_GLOBAL_OVERVIEW
@@ -96,6 +97,7 @@ __all__ = [
     "markets_limits",
     "notify_discord",
     "notify_test",
+    "promo",
     "settings",
     "start_metrics_server",
     "stream_triangles",

--- a/arbit/cli/commands/__init__.py
+++ b/arbit/cli/commands/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from . import config, fitness, keys, live, markets, notify, yield_commands
+from . import config, fitness, keys, live, markets, notify, promo, yield_commands
 
 __all__ = [
     "config",
@@ -11,5 +11,6 @@ __all__ = [
     "live",
     "markets",
     "notify",
+    "promo",
     "yield_commands",
 ]

--- a/arbit/cli/commands/promo.py
+++ b/arbit/cli/commands/promo.py
@@ -1,0 +1,118 @@
+"""CLI command for executing the Kraken ZIG promotion workflow."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+
+import typer
+
+from ..core import TyperOption, app, log
+from ..utils import CCXTAdapter
+
+# Defaults mirror the promotion helper in :mod:`arbit.promo.zig`.
+DEFAULT_TARGET_ZIG = 2500.0
+DEFAULT_QUOTE_ASSET = "USD"
+DEFAULT_SELL_AT = "2024-10-06T00:01:00+00:00"
+
+
+def _parse_datetime(value: str) -> datetime:
+    """Return ``datetime`` parsed from ISO-8601 string *value*."""
+
+    if not value:
+        raise ValueError("Timestamp cannot be empty")
+
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError as exc:
+        if value.endswith("Z"):
+            dt = datetime.fromisoformat(value[:-1] + "+00:00")
+        else:
+            raise ValueError(str(exc)) from exc
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt
+
+
+@app.command("promo")
+def promo(
+    execute: bool = TyperOption(
+        False, "--execute", help="Place live orders when DRY_RUN=false."
+    ),
+    target: float = TyperOption(
+        DEFAULT_TARGET_ZIG,
+        "--target",
+        help="Target ZIG balance to hold before scheduling the sell order.",
+    ),
+    quote: str = TyperOption(
+        DEFAULT_QUOTE_ASSET,
+        "--quote",
+        help="Quote currency for ZIG trades (default: USD).",
+    ),
+    sell_at: str = TyperOption(
+        DEFAULT_SELL_AT,
+        "--sell-at",
+        help="UTC timestamp for liquidation (ISO 8601).",
+    ),
+    check_interval: int = TyperOption(
+        300,
+        "--check-interval",
+        help="Seconds between wake-ups while waiting to sell.",
+    ),
+) -> None:
+    """Buy ZIG up to the target amount and schedule an automatic liquidation."""
+
+    try:
+        target_balance = Decimal(str(target))
+    except InvalidOperation as exc:
+        log.error("promo: invalid --target value: %s", exc)
+        raise typer.Exit(code=1) from exc
+
+    try:
+        sell_at_dt = _parse_datetime(sell_at)
+    except ValueError as exc:
+        log.error("promo: invalid --sell-at timestamp '%s': %s", sell_at, exc)
+        raise typer.Exit(code=1) from exc
+
+    if check_interval <= 0:
+        log.error("promo: --check-interval must be positive")
+        raise typer.Exit(code=1)
+
+    quote = quote.upper()
+
+    adapter = CCXTAdapter("kraken")
+
+    # Import lazily so test suites can stub arbit.config before module import.
+    from arbit.promo.kraken import PromoError
+    from arbit.promo.zig import run_promo_workflow
+
+    async def _runner() -> None:
+        try:
+            await run_promo_workflow(
+                adapter,
+                target_balance=target_balance,
+                sell_at=sell_at_dt,
+                execute=execute,
+                quote=quote,
+                logger=log,
+                check_interval=check_interval,
+            )
+        finally:
+            try:
+                await adapter.close()
+            except RuntimeError:
+                if hasattr(adapter, "ex") and hasattr(adapter.ex, "close"):
+                    adapter.ex.close()
+
+    try:
+        asyncio.run(_runner())
+    except PromoError as exc:
+        log.error("promo failed: %s", exc)
+        raise typer.Exit(code=1) from exc
+
+
+__all__ = ["promo"]

--- a/arbit/cli/help_text.py
+++ b/arbit/cli/help_text.py
@@ -197,6 +197,23 @@ VERBOSE_COMMAND_HELP: dict[str, str] = {
             Better yield available for USDC: foo 5.10% >= current 4.50% + 0.50%
         """
     ),
+    "promo": dedent(
+        """\
+        promo
+          Purpose:
+            Accumulate ZIG on Kraken up to a promotion target and schedule a timed liquidation.
+          Key flags:
+            --execute            Place live orders when DRY_RUN=false (default: dry run).
+            --target FLOAT       Target ZIG balance to maintain (default: 2500).
+            --quote TEXT         Quote currency for ZIG trades (default: USD).
+            --sell-at TEXT       UTC timestamp for liquidation (ISO 8601 format).
+            --check-interval INT Seconds between wake-ups while waiting to sell.
+          Usage tips:
+            - Starts in dry-run mode; rerun with --execute and DRY_RUN=false to trade for real.
+            - Adjust --sell-at for rehearsal runs before the actual promotion deadline.
+            - Keep the process running to allow the scheduled sell leg to execute automatically.
+        """
+    ),
 }
 
 __all__ = ["VERBOSE_GLOBAL_OVERVIEW", "VERBOSE_COMMAND_HELP"]

--- a/arbit/promo/zig.py
+++ b/arbit/promo/zig.py
@@ -1,0 +1,391 @@
+"""Kraken ZIG promotion workflow helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Awaitable, Callable, Mapping, Tuple
+
+from arbit.adapters.ccxt_adapter import CCXTAdapter
+from arbit.config import settings
+from arbit.models import OrderSpec
+
+from .kraken import (
+    FUDGE_FACTOR,
+    PromoError,
+    _apply_precision,
+    _to_decimal,
+    _validate_amount_bounds,
+)
+
+TARGET_ZIG_BALANCE = Decimal("2500")
+"""Default number of ZIG tokens required for the promotion."""
+
+SELL_TIME_UTC = datetime(2024, 10, 6, 0, 1, tzinfo=timezone.utc)
+"""Scheduled liquidation timestamp for the promotion (UTC)."""
+
+DEFAULT_BASE_ASSET = "ZIG"
+DEFAULT_QUOTE_ASSET = "USD"
+DEFAULT_ORDERBOOK_DEPTH = 5
+
+LoggerType = logging.Logger | logging.LoggerAdapter | None
+
+
+@dataclass(frozen=True)
+class BalancePlan:
+    """Plan for acquiring additional ZIG to satisfy the promotion target."""
+
+    symbol: str
+    base: str
+    quote: str
+    target_balance: Decimal
+    current_balance: Decimal
+    quantity: Decimal
+    ask_price: Decimal
+    notional: Decimal
+
+    def needs_purchase(self) -> bool:
+        """Return ``True`` when additional ZIG must be purchased."""
+
+        return self.quantity > 0
+
+    def expected_post_balance(self) -> Decimal:
+        """Return the expected ZIG balance after executing the plan."""
+
+        return self.current_balance + self.quantity
+
+
+@dataclass(frozen=True)
+class SellPlan:
+    """Plan for liquidating accumulated ZIG at the scheduled time."""
+
+    symbol: str
+    base: str
+    quote: str
+    quantity: Decimal
+    bid_price: Decimal
+    notional: Decimal
+
+
+def _market_for(adapter: CCXTAdapter, symbol: str) -> Mapping[str, Any]:
+    """Return market metadata for *symbol* or raise :class:`PromoError`."""
+
+    markets = adapter.load_markets()
+    market = markets.get(symbol)
+    if not market:
+        raise PromoError(f"Symbol {symbol} is not available on Kraken.")
+    return market
+
+
+def plan_accumulation(
+    adapter: CCXTAdapter,
+    target_balance: Decimal,
+    *,
+    base: str = DEFAULT_BASE_ASSET,
+    quote: str = DEFAULT_QUOTE_ASSET,
+    orderbook_depth: int = DEFAULT_ORDERBOOK_DEPTH,
+) -> BalancePlan:
+    """Return a :class:`BalancePlan` describing required ZIG purchases."""
+
+    base = base.upper()
+    quote = quote.upper()
+    symbol = f"{base}/{quote}"
+
+    market = _market_for(adapter, symbol)
+
+    current_balance = _to_decimal(adapter.fetch_balance(base))
+    target_balance = _to_decimal(target_balance)
+
+    deficit = target_balance - current_balance
+    if deficit <= 0:
+        return BalancePlan(
+            symbol=symbol,
+            base=base,
+            quote=quote,
+            target_balance=target_balance,
+            current_balance=current_balance,
+            quantity=Decimal("0"),
+            ask_price=Decimal("0"),
+            notional=Decimal("0"),
+        )
+
+    orderbook = adapter.fetch_orderbook(symbol, orderbook_depth)
+    asks = orderbook.get("asks") or []
+    if not asks:
+        raise PromoError("Order book depth is insufficient to accumulate ZIG.")
+
+    ask_price = _to_decimal(asks[0][0])
+    if ask_price <= 0:
+        raise PromoError("Invalid ask price returned by Kraken.")
+
+    padded_qty = deficit * FUDGE_FACTOR
+    quantity = _apply_precision(padded_qty, market)
+    _validate_amount_bounds(quantity, market)
+
+    if quantity <= 0:
+        raise PromoError(
+            "Rounded ZIG quantity is zero; increase the target balance or "
+            "check market precision settings."
+        )
+
+    expected_post = current_balance + quantity
+    if expected_post < target_balance:
+        shortfall = target_balance - expected_post
+        incremental = _apply_precision(shortfall * FUDGE_FACTOR, market)
+        if incremental <= 0:
+            raise PromoError(
+                "Unable to reach the target balance after applying precision "
+                "constraints. Increase the target or review market precision."
+            )
+        quantity += incremental
+
+    notional = (quantity * ask_price).quantize(Decimal("0.01"))
+
+    return BalancePlan(
+        symbol=symbol,
+        base=base,
+        quote=quote,
+        target_balance=target_balance,
+        current_balance=current_balance,
+        quantity=quantity,
+        ask_price=ask_price,
+        notional=notional,
+    )
+
+
+def execute_accumulation(
+    adapter: CCXTAdapter,
+    plan: BalancePlan,
+    *,
+    execute: bool,
+) -> Mapping[str, Any] | None:
+    """Execute *plan* and return the resulting order when ``execute`` is true."""
+
+    if not plan.needs_purchase() or not execute:
+        return None
+
+    if settings.dry_run:
+        raise PromoError("DRY_RUN is enabled. Export DRY_RUN=false to trade.")
+
+    order = OrderSpec(
+        symbol=plan.symbol,
+        side="buy",
+        quantity=float(plan.quantity),
+        price=None,
+        order_type="market",
+    )
+    return adapter.create_order(order)
+
+
+def plan_liquidation(
+    adapter: CCXTAdapter,
+    *,
+    base: str = DEFAULT_BASE_ASSET,
+    quote: str = DEFAULT_QUOTE_ASSET,
+    orderbook_depth: int = DEFAULT_ORDERBOOK_DEPTH,
+) -> SellPlan | None:
+    """Return a :class:`SellPlan` describing how to liquidate ZIG holdings."""
+
+    base = base.upper()
+    quote = quote.upper()
+    symbol = f"{base}/{quote}"
+
+    market = _market_for(adapter, symbol)
+
+    balance = _to_decimal(adapter.fetch_balance(base))
+    if balance <= 0:
+        return None
+
+    orderbook = adapter.fetch_orderbook(symbol, orderbook_depth)
+    bids = orderbook.get("bids") or []
+    if not bids:
+        raise PromoError("Order book depth is insufficient to liquidate ZIG.")
+
+    bid_price = _to_decimal(bids[0][0])
+    if bid_price <= 0:
+        raise PromoError("Invalid bid price returned by Kraken.")
+
+    quantity = _apply_precision(balance, market)
+    _validate_amount_bounds(quantity, market)
+
+    if quantity <= 0:
+        raise PromoError(
+            "Rounded ZIG quantity is zero; check balance precision before selling."
+        )
+
+    notional = (quantity * bid_price).quantize(Decimal("0.01"))
+
+    return SellPlan(
+        symbol=symbol,
+        base=base,
+        quote=quote,
+        quantity=quantity,
+        bid_price=bid_price,
+        notional=notional,
+    )
+
+
+def execute_liquidation(
+    adapter: CCXTAdapter,
+    plan: SellPlan | None,
+    *,
+    execute: bool,
+) -> Mapping[str, Any] | None:
+    """Execute *plan* and return the resulting sell order when ``execute`` is true."""
+
+    if plan is None or not execute:
+        return None
+
+    if settings.dry_run:
+        raise PromoError("DRY_RUN is enabled. Export DRY_RUN=false to trade.")
+
+    order = OrderSpec(
+        symbol=plan.symbol,
+        side="sell",
+        quantity=float(plan.quantity),
+        price=None,
+        order_type="market",
+    )
+    return adapter.create_order(order)
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC datetime."""
+
+    return datetime.now(timezone.utc)
+
+
+async def wait_until(
+    target: datetime,
+    *,
+    now: Callable[[], datetime] | None = None,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+    check_interval: int = 300,
+) -> None:
+    """Suspend execution until *target* UTC time is reached."""
+
+    now_fn = now or _utcnow
+    sleep_fn = sleep or asyncio.sleep
+
+    if check_interval <= 0:
+        raise ValueError("check_interval must be positive")
+
+    target = target.astimezone(timezone.utc)
+
+    while True:
+        remaining = (target - now_fn()).total_seconds()
+        if remaining <= 0:
+            return
+        await sleep_fn(min(remaining, float(check_interval)))
+
+
+async def run_promo_workflow(
+    adapter: CCXTAdapter,
+    *,
+    target_balance: Decimal = TARGET_ZIG_BALANCE,
+    sell_at: datetime = SELL_TIME_UTC,
+    execute: bool = False,
+    base: str = DEFAULT_BASE_ASSET,
+    quote: str = DEFAULT_QUOTE_ASSET,
+    orderbook_depth: int = DEFAULT_ORDERBOOK_DEPTH,
+    logger: LoggerType = None,
+    now: Callable[[], datetime] | None = None,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+    check_interval: int = 300,
+) -> Tuple[
+    BalancePlan,
+    Mapping[str, Any] | None,
+    SellPlan | None,
+    Mapping[str, Any] | None,
+]:
+    """Run the end-to-end ZIG promotion workflow on Kraken."""
+
+    plan = plan_accumulation(
+        adapter,
+        target_balance,
+        base=base,
+        quote=quote,
+        orderbook_depth=orderbook_depth,
+    )
+    if logger:
+        logger.info(
+            "Promo plan: current=%s target=%s quantity=%s notional≈$%s",
+            plan.current_balance,
+            plan.target_balance,
+            plan.quantity,
+            plan.notional,
+        )
+
+    buy_fill = execute_accumulation(adapter, plan, execute=execute)
+    if logger and buy_fill:
+        logger.info(
+            "Submitted buy order id=%s qty=%s price=%s",
+            buy_fill.get("id"),
+            buy_fill.get("qty"),
+            buy_fill.get("price"),
+        )
+
+    if not execute:
+        if logger:
+            logger.info(
+                "Dry run complete. Re-run with --execute and DRY_RUN=false to trade."
+            )
+        return plan, None, None, None
+
+    await wait_until(
+        sell_at,
+        now=now,
+        sleep=sleep,
+        check_interval=check_interval,
+    )
+
+    sell_plan = plan_liquidation(
+        adapter,
+        base=base,
+        quote=quote,
+        orderbook_depth=orderbook_depth,
+    )
+    if sell_plan is None:
+        if logger:
+            logger.warning(
+                "No ZIG balance detected at liquidation time; skipping sell."
+            )
+        return plan, buy_fill, None, None
+
+    if logger:
+        logger.info(
+            "Liquidation plan: quantity=%s notional≈$%s",
+            sell_plan.quantity,
+            sell_plan.notional,
+        )
+
+    sell_fill = execute_liquidation(adapter, sell_plan, execute=execute)
+    if logger and sell_fill:
+        logger.info(
+            "Submitted sell order id=%s qty=%s price=%s",
+            sell_fill.get("id"),
+            sell_fill.get("qty"),
+            sell_fill.get("price"),
+        )
+
+    return plan, buy_fill, sell_plan, sell_fill
+
+
+__all__ = [
+    "BalancePlan",
+    "SellPlan",
+    "TARGET_ZIG_BALANCE",
+    "SELL_TIME_UTC",
+    "DEFAULT_BASE_ASSET",
+    "DEFAULT_QUOTE_ASSET",
+    "DEFAULT_ORDERBOOK_DEPTH",
+    "plan_accumulation",
+    "execute_accumulation",
+    "plan_liquidation",
+    "execute_liquidation",
+    "wait_until",
+    "run_promo_workflow",
+]

--- a/tests/test_kraken_zig_promo.py
+++ b/tests/test_kraken_zig_promo.py
@@ -1,0 +1,186 @@
+"""Tests for the Kraken ZIG promotion workflow."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from arbit.promo.kraken import PromoError
+from arbit.promo.zig import (
+    TARGET_ZIG_BALANCE,
+    execute_accumulation,
+    plan_accumulation,
+    plan_liquidation,
+    run_promo_workflow,
+    wait_until,
+)
+
+
+class DummyAdapter:
+    """Minimal adapter implementation for exercising promo logic."""
+
+    def __init__(self, balance: Decimal) -> None:
+        self.base_asset = "ZIG"
+        self.quote_asset = "USD"
+        self._balance = Decimal(balance)
+        self.ask_price = Decimal("0.12")
+        self.bid_price = Decimal("0.119")
+        self.orders: list[dict[str, Any]] = []
+        self._markets = {
+            "ZIG/USD": {
+                "base": "ZIG",
+                "quote": "USD",
+                "precision": {"amount": 3},
+                "limits": {"amount": {"min": 0.1}},
+            }
+        }
+
+    def load_markets(self) -> dict[str, Any]:
+        return self._markets
+
+    def fetch_balance(self, asset: str) -> float:
+        if asset.upper() == self.base_asset:
+            return float(self._balance)
+        return 0.0
+
+    def fetch_orderbook(self, symbol: str, depth: int) -> dict[str, Any]:
+        return {
+            "asks": [[float(self.ask_price), 10_000.0]],
+            "bids": [[float(self.bid_price), 10_000.0]],
+        }
+
+    def create_order(self, spec: Any) -> dict[str, Any]:
+        qty = Decimal(str(getattr(spec, "quantity", getattr(spec, "qty"))))
+        side = getattr(spec, "side")
+        price = float(self.ask_price if side == "buy" else self.bid_price)
+        if side == "buy":
+            self._balance += qty
+        else:
+            self._balance -= qty
+        order = {
+            "id": f"{side}-{len(self.orders) + 1}",
+            "symbol": spec.symbol,
+            "side": side,
+            "qty": float(qty),
+            "price": price,
+        }
+        self.orders.append(order)
+        return order
+
+    async def close(self) -> None:  # pragma: no cover - provided for interface parity
+        return None
+
+
+def test_plan_accumulation_requires_purchase() -> None:
+    """Planning should request a buy when the balance is below target."""
+
+    adapter = DummyAdapter(Decimal("1000"))
+    plan = plan_accumulation(adapter, TARGET_ZIG_BALANCE)
+    assert plan.needs_purchase()
+    assert plan.quantity > 0
+    assert plan.expected_post_balance() >= TARGET_ZIG_BALANCE
+
+
+def test_plan_accumulation_skips_when_balance_sufficient() -> None:
+    """No purchase should be required when the account already meets the target."""
+
+    adapter = DummyAdapter(Decimal("2600"))
+    plan = plan_accumulation(adapter, TARGET_ZIG_BALANCE)
+    assert not plan.needs_purchase()
+    assert plan.quantity == 0
+
+
+def test_execute_accumulation_respects_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Execution must raise when DRY_RUN is active."""
+
+    from arbit.config import settings
+
+    adapter = DummyAdapter(Decimal("2000"))
+    plan = plan_accumulation(adapter, TARGET_ZIG_BALANCE)
+    monkeypatch.setattr(settings, "dry_run", True)
+    with pytest.raises(PromoError):
+        execute_accumulation(adapter, plan, execute=True)
+
+
+def test_plan_liquidation_handles_empty_balance() -> None:
+    """When no ZIG is held, liquidation planning should return ``None``."""
+
+    adapter = DummyAdapter(Decimal("0"))
+    assert plan_liquidation(adapter) is None
+
+
+@pytest.mark.asyncio
+async def test_wait_until_advances_time() -> None:
+    """wait_until should sleep until the scheduled timestamp."""
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    target = start + timedelta(seconds=120)
+    calls: list[float] = []
+
+    class Controller:
+        def __init__(self) -> None:
+            self.current = start
+
+        def now(self) -> datetime:
+            return self.current
+
+        async def sleep(self, seconds: float) -> None:
+            calls.append(seconds)
+            self.current += timedelta(seconds=seconds)
+
+    controller = Controller()
+    await wait_until(
+        target, now=controller.now, sleep=controller.sleep, check_interval=30
+    )
+    assert controller.current >= target
+    assert calls  # ensure sleep was invoked
+
+
+@pytest.mark.asyncio
+async def test_run_promo_workflow_places_buy_and_sell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end workflow should buy then sell when execution is enabled."""
+
+    from arbit.config import settings
+
+    adapter = DummyAdapter(Decimal("1500"))
+    monkeypatch.setattr(settings, "dry_run", False)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    controller_times: list[float] = []
+
+    class Controller:
+        def __init__(self) -> None:
+            self.current = start
+
+        def now(self) -> datetime:
+            return self.current
+
+        async def sleep(self, seconds: float) -> None:
+            controller_times.append(seconds)
+            self.current += timedelta(seconds=seconds)
+
+    controller = Controller()
+    sell_at = start + timedelta(seconds=90)
+
+    plan, buy_fill, sell_plan, sell_fill = await run_promo_workflow(
+        adapter,
+        target_balance=TARGET_ZIG_BALANCE,
+        sell_at=sell_at,
+        execute=True,
+        now=controller.now,
+        sleep=controller.sleep,
+        check_interval=30,
+    )
+
+    assert plan.needs_purchase()
+    assert buy_fill is not None
+    assert sell_plan is not None
+    assert sell_fill is not None
+    assert controller_times  # ensures wait_until slept at least once
+    assert adapter.orders[0]["side"] == "buy"
+    assert adapter.orders[-1]["side"] == "sell"


### PR DESCRIPTION
## Summary
- add a `promo` CLI command that tops up Kraken ZIG balances and schedules liquidation at the configured UTC timestamp
- implement reusable helpers under `arbit.promo.zig` plus targeted unit tests for the workflow
- document the new promo helper in the README and verbose CLI help text

## Testing
- (cd /tmp && PYENV_VERSION=3.11.12 python -m black /workspace/Arbit/arbit/promo/zig.py /workspace/Arbit/arbit/cli/commands/promo.py /workspace/Arbit/tests/test_kraken_zig_promo.py)
- (cd /tmp && PYENV_VERSION=3.11.12 python -m ruff check /workspace/Arbit/arbit/promo/zig.py /workspace/Arbit/arbit/cli/commands/promo.py /workspace/Arbit/tests/test_kraken_zig_promo.py)
- PYENV_VERSION=3.11.12 pytest *(fails: missing optional dependencies such as pydantic and prometheus_client in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dcde82bfa08329b1929c7dcf8138ac